### PR TITLE
Integrate custom Jetstream and Fortify auth experience

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+
+class CreateNewUser
+{
+    use PasswordValidationRules;
+
+    public function create(array $input): User
+    {
+        $validator = Validator::make($input, [
+            'name' => ['nullable', 'string', 'max:255'],
+            'email' => [
+                'required',
+                'string',
+                'lowercase',
+                'email',
+                'max:255',
+                Rule::unique(User::class),
+            ],
+            'birthdate' => [
+                'required',
+                'date',
+                'before_or_equal:'.now()->subYears(18)->toDateString(),
+            ],
+            'password' => $this->passwordRules(),
+            'captcha' => ['accepted'],
+        ], [
+            'birthdate.before_or_equal' => __('Vous devez avoir au moins 18 ans pour vous inscrire.'),
+        ]);
+
+        $validator->validate();
+
+        return User::create([
+            'name' => $this->resolveName($input),
+            'email' => strtolower($input['email']),
+            'birthdate' => $input['birthdate'],
+            'password' => Hash::make($input['password']),
+        ]);
+    }
+
+    protected function resolveName(array $input): string
+    {
+        $name = trim((string) ($input['name'] ?? ''));
+
+        if ($name !== '') {
+            return $name;
+        }
+
+        $email = (string) ($input['email'] ?? '');
+
+        if ($email !== '') {
+            return Str::before($email, '@');
+        }
+
+        return __('Invité Totem');
+    }
+}

--- a/app/Actions/Fortify/PasswordValidationRules.php
+++ b/app/Actions/Fortify/PasswordValidationRules.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use Illuminate\Validation\Rules\Password;
+
+trait PasswordValidationRules
+{
+    /**
+     * Get the validation rules used to validate passwords.
+     *
+     * @return array<int, mixed>
+     */
+    protected function passwordRules(): array
+    {
+        return [
+            'required',
+            'string',
+            'confirmed',
+            Password::defaults(),
+        ];
+    }
+}

--- a/app/Fortify/Fortify.php
+++ b/app/Fortify/Fortify.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Laravel\Fortify;
+
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+
+class Fortify
+{
+    /**
+     * The callbacks used to render Fortify views.
+     *
+     * @var array<string, callable|null>
+     */
+    protected static array $viewCallbacks = [
+        'login' => null,
+        'register' => null,
+        'requestPasswordResetLink' => null,
+        'resetPassword' => null,
+        'confirmPassword' => null,
+        'verifyEmail' => null,
+    ];
+
+    public static function loginView(callable $callback): void
+    {
+        static::$viewCallbacks['login'] = $callback;
+    }
+
+    public static function registerView(callable $callback): void
+    {
+        static::$viewCallbacks['register'] = $callback;
+    }
+
+    public static function requestPasswordResetLinkView(callable $callback): void
+    {
+        static::$viewCallbacks['requestPasswordResetLink'] = $callback;
+    }
+
+    public static function resetPasswordView(callable $callback): void
+    {
+        static::$viewCallbacks['resetPassword'] = $callback;
+    }
+
+    public static function confirmPasswordView(callable $callback): void
+    {
+        static::$viewCallbacks['confirmPassword'] = $callback;
+    }
+
+    public static function verifyEmailView(callable $callback): void
+    {
+        static::$viewCallbacks['verifyEmail'] = $callback;
+    }
+
+    public static function renderLoginView(Request $request): Response
+    {
+        return static::render('login', $request);
+    }
+
+    public static function renderRegisterView(Request $request): Response
+    {
+        return static::render('register', $request);
+    }
+
+    public static function renderRequestPasswordResetLinkView(Request $request): Response
+    {
+        return static::render('requestPasswordResetLink', $request);
+    }
+
+    public static function renderResetPasswordView(Request $request): Response
+    {
+        return static::render('resetPassword', $request);
+    }
+
+    public static function renderConfirmPasswordView(Request $request): Response
+    {
+        return static::render('confirmPassword', $request);
+    }
+
+    public static function renderVerifyEmailView(Request $request): Response
+    {
+        return static::render('verifyEmail', $request);
+    }
+
+    public static function hasView(string $key): bool
+    {
+        return isset(static::$viewCallbacks[$key]) && is_callable(static::$viewCallbacks[$key]);
+    }
+
+    protected static function render(string $key, Request $request): Response
+    {
+        $callback = static::$viewCallbacks[$key] ?? null;
+
+        if (! is_callable($callback)) {
+            throw new InvalidArgumentException("Fortify view [{$key}] has not been defined.");
+        }
+
+        return value($callback, $request);
+    }
+}

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -7,21 +7,17 @@ use App\Http\Requests\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class AuthenticatedSessionController extends Controller
 {
     /**
      * Display the login view.
      */
-    public function create(): Response
+    public function create(Request $request): Response
     {
-        return Inertia::render('Auth/Login', [
-            'canResetPassword' => Route::has('password.request'),
-            'status' => session('status'),
-        ]);
+        return Fortify::renderLoginView($request);
     }
 
     /**

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -7,17 +7,17 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
-use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class ConfirmablePasswordController extends Controller
 {
     /**
      * Show the confirm password view.
      */
-    public function show(): Response
+    public function show(Request $request): Response
     {
-        return Inertia::render('Auth/ConfirmPassword');
+        return Fortify::renderConfirmPasswordView($request);
     }
 
     /**

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class EmailVerificationPromptController extends Controller
 {
@@ -17,6 +17,6 @@ class EmailVerificationPromptController extends Controller
     {
         return $request->user()->hasVerifiedEmail()
                     ? redirect()->intended(route('dashboard', absolute: false))
-                    : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
+                    : Fortify::renderVerifyEmailView($request);
     }
 }

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
-use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class NewPasswordController extends Controller
 {
@@ -21,10 +21,7 @@ class NewPasswordController extends Controller
      */
     public function create(Request $request): Response
     {
-        return Inertia::render('Auth/ResetPassword', [
-            'email' => $request->email,
-            'token' => $request->route('token'),
-        ]);
+        return Fortify::renderResetPasswordView($request);
     }
 
     /**

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -7,19 +7,17 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
-use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class PasswordResetLinkController extends Controller
 {
     /**
      * Display the password reset link request view.
      */
-    public function create(): Response
+    public function create(Request $request): Response
     {
-        return Inertia::render('Auth/ForgotPassword', [
-            'status' => session('status'),
-        ]);
+        return Fortify::renderRequestPasswordResetLinkView($request);
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -2,50 +2,72 @@
 
 namespace App\Http\Controllers\Auth;
 
+use App\Actions\Fortify\CreateNewUser;
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
-use Inertia\Inertia;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Validation\ValidationException;
 use Inertia\Response;
+use Laravel\Fortify\Fortify;
 
 class RegisteredUserController extends Controller
 {
+    public function __construct(private CreateNewUser $creator)
+    {
+    }
+
     /**
      * Display the registration view.
      */
-    public function create(): Response
+    public function create(Request $request): Response
     {
-        return Inertia::render('Auth/Register');
+        return Fortify::renderRegisterView($request);
     }
 
     /**
      * Handle an incoming registration request.
-     *
-     * @throws \Illuminate\Validation\ValidationException
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        $this->ensureIsNotRateLimited($request);
 
-        $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
-        ]);
+        $key = $this->registerThrottleKey($request);
+        $decay = max(1, (int) config('fortify.limiters.register.decay_minutes', 5)) * 60;
+
+        RateLimiter::hit($key, $decay);
+
+        $user = $this->creator->create($request->all());
+
+        RateLimiter::clear($key);
 
         event(new Registered($user));
 
-        Auth::login($user);
+        return redirect()->route('register.complete');
+    }
 
-        return redirect(route('dashboard', absolute: false));
+    protected function ensureIsNotRateLimited(Request $request): void
+    {
+        $key = $this->registerThrottleKey($request);
+        $maxAttempts = max(1, (int) config('fortify.limiters.register.max_attempts', 3));
+
+        if (! RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            return;
+        }
+
+        $seconds = RateLimiter::availableIn($key);
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => (int) ceil($seconds / 60),
+            ]),
+        ]);
+    }
+
+    protected function registerThrottleKey(Request $request): string
+    {
+        return 'register|'.$request->ip();
     }
 }

--- a/app/Jetstream/Jetstream.php
+++ b/app/Jetstream/Jetstream.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Laravel\Jetstream;
+
+use Illuminate\Support\Arr;
+use Laravel\Fortify\Fortify;
+
+class Jetstream
+{
+    /**
+     * The current stack Jetstream should use.
+     */
+    protected static string $stack = 'livewire';
+
+    public static function useInertia(): void
+    {
+        static::$stack = 'inertia';
+
+        config(['jetstream.stack' => 'inertia']);
+    }
+
+    public static function stack(): string
+    {
+        return static::$stack;
+    }
+
+    public static function loginView(callable $callback): void
+    {
+        Fortify::loginView($callback);
+    }
+
+    public static function registerView(callable $callback): void
+    {
+        Fortify::registerView($callback);
+    }
+
+    public static function requestPasswordResetLinkView(callable $callback): void
+    {
+        Fortify::requestPasswordResetLinkView($callback);
+    }
+
+    public static function resetPasswordView(callable $callback): void
+    {
+        Fortify::resetPasswordView($callback);
+    }
+
+    public static function confirmPasswordView(callable $callback): void
+    {
+        Fortify::confirmPasswordView($callback);
+    }
+
+    public static function verifyEmailView(callable $callback): void
+    {
+        Fortify::verifyEmailView($callback);
+    }
+
+    public static function defaultApiTokenPermissions(array $permissions): void
+    {
+        config(['jetstream.permissions.default' => $permissions]);
+    }
+
+    public static function permissions(array $permissions): void
+    {
+        config(['jetstream.permissions.available' => $permissions]);
+    }
+
+    public static function hasFeature(string $feature): bool
+    {
+        return in_array($feature, config('jetstream.features', []), true);
+    }
+
+    public static function feature(string $feature, mixed $default = null): mixed
+    {
+        return Arr::get(config('jetstream.features', []), $feature, $default);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'birthdate',
         'password',
     ];
 
@@ -42,6 +43,7 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
+            'birthdate' => 'date',
             'password' => 'hashed',
         ];
     }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\ServiceProvider;
+
+class FortifyServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->configureRateLimiting();
+    }
+
+    protected function configureRateLimiting(): void
+    {
+        $loginConfig = config('fortify.limiters.login', []);
+        $loginKey = (string) data_get($loginConfig, 'key', 'login');
+        $loginAttempts = max(1, (int) data_get($loginConfig, 'max_attempts', 5));
+        $loginDecay = max(1, (int) data_get($loginConfig, 'decay_minutes', 1));
+
+        RateLimiter::for($loginKey, function (Request $request) use ($loginAttempts, $loginDecay) {
+            $email = strtolower((string) $request->input('email', 'guest'));
+
+            return Limit::perMinutes($loginDecay, $loginAttempts)->by($email.'|'.$request->ip());
+        });
+
+        $registerConfig = config('fortify.limiters.register', []);
+        $registerKey = (string) data_get($registerConfig, 'key', 'register');
+        $registerAttempts = max(1, (int) data_get($registerConfig, 'max_attempts', 3));
+        $registerDecay = max(1, (int) data_get($registerConfig, 'decay_minutes', 5));
+
+        RateLimiter::for($registerKey, function (Request $request) use ($registerAttempts, $registerDecay) {
+            return Limit::perMinutes($registerDecay, $registerAttempts)->by($request->ip());
+        });
+    }
+}

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Inertia\Inertia;
+use Laravel\Jetstream\Jetstream;
+
+class JetstreamServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Jetstream::useInertia();
+
+        Jetstream::loginView(function (Request $request) {
+            return Inertia::render('Auth/Login', [
+                'status' => $request->session()->get('status'),
+                'canResetPassword' => Route::has('password.request'),
+                'canRegister' => Route::has('register'),
+            ]);
+        });
+
+        Jetstream::registerView(fn (Request $request) => Inertia::render('Auth/Register'));
+
+        Jetstream::requestPasswordResetLinkView(function (Request $request) {
+            return Inertia::render('Auth/ForgotPassword', [
+                'status' => $request->session()->get('status'),
+            ]);
+        });
+
+        Jetstream::resetPasswordView(function (Request $request) {
+            return Inertia::render('Auth/ResetPassword', [
+                'token' => $request->route('token'),
+                'email' => $request->query('email'),
+            ]);
+        });
+
+        Jetstream::confirmPasswordView(fn (Request $request) => Inertia::render('Auth/ConfirmPassword'));
+
+        Jetstream::verifyEmailView(function (Request $request) {
+            return Inertia::render('Auth/VerifyEmail', [
+                'status' => $request->session()->get('status'),
+            ]);
+        });
+
+        $this->configurePermissions();
+    }
+
+    protected function configurePermissions(): void
+    {
+        Jetstream::defaultApiTokenPermissions(['read']);
+
+        Jetstream::permissions([
+            'create',
+            'read',
+            'update',
+            'delete',
+        ]);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\FortifyServiceProvider::class,
+    App\Providers\JetstreamServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,10 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.2",
@@ -27,7 +30,9 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
+            "Database\\Seeders\\": "database/seeders/",
+            "Laravel\\Fortify\\": "app/Fortify/",
+            "Laravel\\Jetstream\\": "app/Jetstream/"
         }
     },
     "autoload-dev": {

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'guard' => 'web',
+
+    'home' => '/dashboard',
+
+    'middleware' => ['web'],
+
+    'limiters' => [
+        'login' => [
+            'key' => 'login',
+            'max_attempts' => env('FORTIFY_LOGIN_MAX_ATTEMPTS', 5),
+            'decay_minutes' => env('FORTIFY_LOGIN_DECAY_MINUTES', 1),
+        ],
+
+        'register' => [
+            'key' => 'register',
+            'max_attempts' => env('FORTIFY_REGISTER_MAX_ATTEMPTS', 3),
+            'decay_minutes' => env('FORTIFY_REGISTER_DECAY_MINUTES', 5),
+        ],
+    ],
+
+    'features' => [
+        'email-verification',
+    ],
+];

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'stack' => env('JETSTREAM_STACK', 'inertia'),
+
+    'middleware' => ['web'],
+
+    'features' => [
+        'profile-photos' => false,
+        'account-deletion' => false,
+    ],
+
+    'profile_photo_disk' => env('JETSTREAM_PROFILE_PHOTO_DISK', 'public'),
+
+    'profile_photo_path' => env('JETSTREAM_PROFILE_PHOTO_PATH', 'profile-photos'),
+
+    'guard' => env('JETSTREAM_GUARD', 'web'),
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,6 +27,7 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
+            'birthdate' => fake()->dateTimeBetween('-60 years', '-20 years')->format('Y-m-d'),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->date('birthdate');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/resources/js/Pages/Auth/ConfirmPassword.jsx
+++ b/resources/js/Pages/Auth/ConfirmPassword.jsx
@@ -2,7 +2,7 @@ import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextInput from '@/Components/TextInput';
-import GuestLayout from '@/Layouts/GuestLayout';
+import AuthLayout from '@/Layouts/AuthLayout';
 import { Head, useForm } from '@inertiajs/react';
 
 export default function ConfirmPassword() {
@@ -18,38 +18,78 @@ export default function ConfirmPassword() {
         });
     };
 
+    const asideContent = (
+        <div className="flex flex-col items-center text-center text-white">
+            <img
+                src="/images/Logo-blanc.png"
+                alt="Logo Totem Mind"
+                className="w-40"
+            />
+
+            <p className="mt-10 max-w-sm text-lg text-white/80">
+                Cette étape garantit la sécurité de votre compte avant
+                d'accéder aux paramètres sensibles.
+            </p>
+        </div>
+    );
+
     return (
-        <GuestLayout>
-            <Head title="Confirm Password" />
+        <AuthLayout
+            aside={asideContent}
+            asideClassName="bg-brand-midnight"
+            backgroundClassName="bg-brand-ocean"
+            footerVariant="light"
+        >
+            <Head title="Confirmation du mot de passe" />
 
-            <div className="mb-4 text-sm text-gray-600">
-                This is a secure area of the application. Please confirm your
-                password before continuing.
-            </div>
-
-            <form onSubmit={submit}>
-                <div className="mt-4">
-                    <InputLabel htmlFor="password" value="Password" />
-
-                    <TextInput
-                        id="password"
-                        type="password"
-                        name="password"
-                        value={data.password}
-                        className="mt-1 block w-full"
-                        isFocused={true}
-                        onChange={(e) => setData('password', e.target.value)}
-                    />
-
-                    <InputError message={errors.password} className="mt-2" />
+            <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/10 backdrop-blur">
+                <div className="text-center">
+                    <h1 className="text-4xl font-semibold text-white">
+                        Confirmez votre identité
+                    </h1>
+                    <p className="mt-4 text-sm text-white/70">
+                        Pour protéger vos informations, veuillez saisir votre
+                        mot de passe avant de poursuivre.
+                    </p>
                 </div>
 
-                <div className="mt-4 flex items-center justify-end">
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Confirm
+                <form className="mt-10 space-y-7" onSubmit={submit}>
+                    <div>
+                        <InputLabel
+                            htmlFor="password"
+                            value="Mot de passe"
+                            variant="brand"
+                        />
+
+                        <TextInput
+                            id="password"
+                            type="password"
+                            name="password"
+                            value={data.password}
+                            variant="brand"
+                            autoComplete="current-password"
+                            isFocused
+                            onChange={(e) => setData('password', e.target.value)}
+                            required
+                        />
+
+                        <InputError
+                            message={errors.password}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
+
+                    <PrimaryButton
+                        type="submit"
+                        variant="brand"
+                        disabled={processing}
+                        className="w-full"
+                    >
+                        Confirmer
                     </PrimaryButton>
-                </div>
-            </form>
-        </GuestLayout>
+                </form>
+            </div>
+        </AuthLayout>
     );
 }

--- a/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -1,7 +1,8 @@
 import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextInput from '@/Components/TextInput';
-import GuestLayout from '@/Layouts/GuestLayout';
+import AuthLayout from '@/Layouts/AuthLayout';
 import { Head, useForm } from '@inertiajs/react';
 
 export default function ForgotPassword({ status }) {
@@ -15,41 +16,85 @@ export default function ForgotPassword({ status }) {
         post(route('password.email'));
     };
 
+    const asideContent = (
+        <div className="flex flex-col items-center text-center text-white">
+            <img
+                src="/images/paysage-bleu.png"
+                alt="Illustration d'un paysage nocturne"
+                className="w-full max-w-sm"
+            />
+
+            <p className="mt-10 max-w-sm text-lg text-white/80">
+                Recevez un lien sécurisé pour réinitialiser votre mot de passe
+                et reprendre votre parcours Totem Mind en toute sérénité.
+            </p>
+        </div>
+    );
+
     return (
-        <GuestLayout>
-            <Head title="Forgot Password" />
+        <AuthLayout
+            aside={asideContent}
+            asideClassName="bg-brand-midnight"
+            backgroundClassName="bg-brand-ocean"
+            footerVariant="light"
+        >
+            <Head title="Mot de passe oublié" />
 
-            <div className="mb-4 text-sm text-gray-600">
-                Forgot your password? No problem. Just let us know your email
-                address and we will email you a password reset link that will
-                allow you to choose a new one.
-            </div>
-
-            {status && (
-                <div className="mb-4 text-sm font-medium text-green-600">
-                    {status}
+            <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/10 backdrop-blur">
+                <div className="text-center">
+                    <h1 className="text-4xl font-semibold text-white">
+                        Mot de passe oublié
+                    </h1>
+                    <p className="mt-4 text-sm text-white/70">
+                        Indiquez votre adresse mail et nous vous enverrons un
+                        lien pour définir un nouveau mot de passe.
+                    </p>
                 </div>
-            )}
 
-            <form onSubmit={submit}>
-                <TextInput
-                    id="email"
-                    type="email"
-                    name="email"
-                    value={data.email}
-                    className="mt-1 block w-full"
-                    isFocused={true}
-                    onChange={(e) => setData('email', e.target.value)}
-                />
+                {status && (
+                    <div className="mt-6 rounded-full bg-emerald-400/20 px-6 py-3 text-center text-sm font-semibold text-emerald-100">
+                        {status}
+                    </div>
+                )}
 
-                <InputError message={errors.email} className="mt-2" />
+                <form className="mt-10 space-y-7" onSubmit={submit}>
+                    <div>
+                        <InputLabel
+                            htmlFor="email"
+                            value="Adresse mail"
+                            variant="brand"
+                        />
 
-                <div className="mt-4 flex items-center justify-end">
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Email Password Reset Link
+                        <TextInput
+                            id="email"
+                            type="email"
+                            name="email"
+                            value={data.email}
+                            variant="brand"
+                            placeholder="nom@exemple.com"
+                            autoComplete="email"
+                            isFocused
+                            onChange={(e) => setData('email', e.target.value)}
+                            required
+                        />
+
+                        <InputError
+                            message={errors.email}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
+
+                    <PrimaryButton
+                        type="submit"
+                        variant="brand"
+                        disabled={processing}
+                        className="w-full"
+                    >
+                        Envoyer le lien de réinitialisation
                     </PrimaryButton>
-                </div>
-            </form>
-        </GuestLayout>
+                </form>
+            </div>
+        </AuthLayout>
     );
 }

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -3,98 +3,167 @@ import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextInput from '@/Components/TextInput';
-import GuestLayout from '@/Layouts/GuestLayout';
+import AuthLayout from '@/Layouts/AuthLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
 
-export default function Login({ status, canResetPassword }) {
+export default function Login({ status, canResetPassword, canRegister }) {
     const { data, setData, post, processing, errors, reset } = useForm({
         email: '',
         password: '',
         remember: false,
     });
 
+    useEffect(() => {
+        return () => {
+            reset('password');
+        };
+    }, [reset]);
+
     const submit = (e) => {
         e.preventDefault();
 
-        post(route('login'), {
-            onFinish: () => reset('password'),
-        });
+        post(route('login'));
     };
 
+    const asideContent = (
+        <div className="flex flex-col items-center text-center text-white">
+            <img
+                src="/images/lézard-blanc.png"
+                alt="Illustration d'un lézard"
+                className="w-full max-w-sm"
+            />
+
+            <p className="mt-10 max-w-sm text-lg text-white/80">
+                Accédez à votre espace Totem Mind pour continuer vos quêtes,
+                suivre vos gains et profiter des sondages exclusifs.
+            </p>
+        </div>
+    );
+
     return (
-        <GuestLayout>
-            <Head title="Log in" />
+        <AuthLayout
+            aside={asideContent}
+            asideClassName="bg-brand-ocean"
+            backgroundClassName="bg-brand-midnight"
+            footerVariant="light"
+        >
+            <Head title="Connexion" />
 
-            {status && (
-                <div className="mb-4 text-sm font-medium text-green-600">
-                    {status}
-                </div>
-            )}
-
-            <form onSubmit={submit}>
-                <div>
-                    <InputLabel htmlFor="email" value="Email" />
-
-                    <TextInput
-                        id="email"
-                        type="email"
-                        name="email"
-                        value={data.email}
-                        className="mt-1 block w-full"
-                        autoComplete="username"
-                        isFocused={true}
-                        onChange={(e) => setData('email', e.target.value)}
-                    />
-
-                    <InputError message={errors.email} className="mt-2" />
+            <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/20 backdrop-blur">
+                <div className="text-center">
+                    <h1 className="text-4xl font-semibold text-white">
+                        Se connecter
+                    </h1>
+                    <p className="mt-4 text-sm text-white/70">
+                        Retrouvez votre espace personnel et continuez l'aventure
+                        Totem Mind.
+                    </p>
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel htmlFor="password" value="Password" />
+                {status && (
+                    <div className="mt-6 rounded-full bg-emerald-400/20 px-6 py-3 text-center text-sm font-semibold text-emerald-100">
+                        {status}
+                    </div>
+                )}
 
-                    <TextInput
-                        id="password"
-                        type="password"
-                        name="password"
-                        value={data.password}
-                        className="mt-1 block w-full"
-                        autoComplete="current-password"
-                        onChange={(e) => setData('password', e.target.value)}
-                    />
-
-                    <InputError message={errors.password} className="mt-2" />
-                </div>
-
-                <div className="mt-4 block">
-                    <label className="flex items-center">
-                        <Checkbox
-                            name="remember"
-                            checked={data.remember}
-                            onChange={(e) =>
-                                setData('remember', e.target.checked)
-                            }
+                <form className="mt-10 space-y-7" onSubmit={submit}>
+                    <div>
+                        <InputLabel
+                            htmlFor="email"
+                            value="Adresse mail"
+                            variant="brand"
                         />
-                        <span className="ms-2 text-sm text-gray-600">
-                            Remember me
-                        </span>
-                    </label>
-                </div>
 
-                <div className="mt-4 flex items-center justify-end">
-                    {canResetPassword && (
-                        <Link
-                            href={route('password.request')}
-                            className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                        >
-                            Forgot your password?
-                        </Link>
-                    )}
+                        <TextInput
+                            id="email"
+                            type="email"
+                            name="email"
+                            value={data.email}
+                            variant="brand"
+                            placeholder="nom@exemple.com"
+                            autoComplete="email"
+                            onChange={(e) => setData('email', e.target.value)}
+                            required
+                        />
 
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Log in
+                        <InputError
+                            message={errors.email}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
+
+                    <div>
+                        <InputLabel
+                            htmlFor="password"
+                            value="Mot de passe"
+                            variant="brand"
+                        />
+
+                        <TextInput
+                            id="password"
+                            type="password"
+                            name="password"
+                            value={data.password}
+                            variant="brand"
+                            autoComplete="current-password"
+                            onChange={(e) => setData('password', e.target.value)}
+                            required
+                        />
+
+                        <InputError
+                            message={errors.password}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                        <label className="flex items-center gap-3 text-sm text-white/90">
+                            <Checkbox
+                                name="remember"
+                                checked={data.remember}
+                                onChange={(e) =>
+                                    setData('remember', e.target.checked)
+                                }
+                                className="size-5 border-white/40 text-brand-sand focus:ring-brand-sand focus:ring-offset-0"
+                            />
+                            <span>Se souvenir de moi</span>
+                        </label>
+
+                        {canResetPassword && (
+                            <Link
+                                href={route('password.request')}
+                                className="text-sm font-semibold text-white hover:text-brand-sand"
+                            >
+                                Mot de passe oublié ?
+                            </Link>
+                        )}
+                    </div>
+
+                    <PrimaryButton
+                        type="submit"
+                        variant="brand"
+                        disabled={processing}
+                        className="w-full"
+                    >
+                        Se connecter
                     </PrimaryButton>
-                </div>
-            </form>
-        </GuestLayout>
+                </form>
+            </div>
+
+            {canRegister && (
+                <p className="mt-12 text-center text-sm text-white/80">
+                    Pas encore de compte ?{' '}
+                    <Link
+                        href={route('register')}
+                        className="font-semibold text-white hover:text-brand-sand"
+                    >
+                        Inscrivez-vous !
+                    </Link>
+                </p>
+            )}
+        </AuthLayout>
     );
 }

--- a/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/resources/js/Pages/Auth/ResetPassword.jsx
@@ -2,13 +2,13 @@ import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextInput from '@/Components/TextInput';
-import GuestLayout from '@/Layouts/GuestLayout';
+import AuthLayout from '@/Layouts/AuthLayout';
 import { Head, useForm } from '@inertiajs/react';
 
 export default function ResetPassword({ token, email }) {
     const { data, setData, post, processing, errors, reset } = useForm({
         token: token,
-        email: email,
+        email: email ?? '',
         password: '',
         password_confirmation: '',
     });
@@ -21,74 +21,131 @@ export default function ResetPassword({ token, email }) {
         });
     };
 
+    const asideContent = (
+        <div className="flex flex-col items-center text-center text-white">
+            <img
+                src="/images/palette.png"
+                alt="Palette de couleurs Totem"
+                className="w-full max-w-sm"
+            />
+
+            <p className="mt-10 max-w-sm text-lg text-white/80">
+                Choisissez un nouveau mot de passe sécurisé pour continuer vos
+                explorations dans l’univers Totem Mind.
+            </p>
+        </div>
+    );
+
     return (
-        <GuestLayout>
-            <Head title="Reset Password" />
+        <AuthLayout
+            aside={asideContent}
+            asideClassName="bg-brand-midnight"
+            backgroundClassName="bg-brand-ocean"
+            footerVariant="light"
+        >
+            <Head title="Réinitialisation du mot de passe" />
 
-            <form onSubmit={submit}>
-                <div>
-                    <InputLabel htmlFor="email" value="Email" />
-
-                    <TextInput
-                        id="email"
-                        type="email"
-                        name="email"
-                        value={data.email}
-                        className="mt-1 block w-full"
-                        autoComplete="username"
-                        onChange={(e) => setData('email', e.target.value)}
-                    />
-
-                    <InputError message={errors.email} className="mt-2" />
+            <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/10 backdrop-blur">
+                <div className="text-center">
+                    <h1 className="text-4xl font-semibold text-white">
+                        Définir un nouveau mot de passe
+                    </h1>
+                    <p className="mt-4 text-sm text-white/70">
+                        Saisissez votre adresse mail puis votre nouveau mot de
+                        passe pour sécuriser votre compte.
+                    </p>
                 </div>
 
-                <div className="mt-4">
-                    <InputLabel htmlFor="password" value="Password" />
+                <form className="mt-10 space-y-7" onSubmit={submit}>
+                    <div>
+                        <InputLabel
+                            htmlFor="email"
+                            value="Adresse mail"
+                            variant="brand"
+                        />
 
-                    <TextInput
-                        id="password"
-                        type="password"
-                        name="password"
-                        value={data.password}
-                        className="mt-1 block w-full"
-                        autoComplete="new-password"
-                        isFocused={true}
-                        onChange={(e) => setData('password', e.target.value)}
-                    />
+                        <TextInput
+                            id="email"
+                            type="email"
+                            name="email"
+                            value={data.email}
+                            variant="brand"
+                            placeholder="nom@exemple.com"
+                            autoComplete="email"
+                            onChange={(e) => setData('email', e.target.value)}
+                            required
+                        />
 
-                    <InputError message={errors.password} className="mt-2" />
-                </div>
+                        <InputError
+                            message={errors.email}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
 
-                <div className="mt-4">
-                    <InputLabel
-                        htmlFor="password_confirmation"
-                        value="Confirm Password"
-                    />
+                    <div>
+                        <InputLabel
+                            htmlFor="password"
+                            value="Nouveau mot de passe"
+                            variant="brand"
+                        />
 
-                    <TextInput
-                        type="password"
-                        id="password_confirmation"
-                        name="password_confirmation"
-                        value={data.password_confirmation}
-                        className="mt-1 block w-full"
-                        autoComplete="new-password"
-                        onChange={(e) =>
-                            setData('password_confirmation', e.target.value)
-                        }
-                    />
+                        <TextInput
+                            id="password"
+                            type="password"
+                            name="password"
+                            value={data.password}
+                            variant="brand"
+                            autoComplete="new-password"
+                            isFocused
+                            onChange={(e) => setData('password', e.target.value)}
+                            required
+                        />
 
-                    <InputError
-                        message={errors.password_confirmation}
-                        className="mt-2"
-                    />
-                </div>
+                        <InputError
+                            message={errors.password}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
 
-                <div className="mt-4 flex items-center justify-end">
-                    <PrimaryButton className="ms-4" disabled={processing}>
-                        Reset Password
+                    <div>
+                        <InputLabel
+                            htmlFor="password_confirmation"
+                            value="Confirmation"
+                            variant="brand"
+                        />
+
+                        <TextInput
+                            id="password_confirmation"
+                            type="password"
+                            name="password_confirmation"
+                            value={data.password_confirmation}
+                            variant="brand"
+                            autoComplete="new-password"
+                            onChange={(e) =>
+                                setData('password_confirmation', e.target.value)
+                            }
+                            required
+                        />
+
+                        <InputError
+                            message={errors.password_confirmation}
+                            variant="brand"
+                            className="mt-2"
+                        />
+                    </div>
+
+                    <PrimaryButton
+                        type="submit"
+                        variant="brand"
+                        disabled={processing}
+                        className="w-full"
+                    >
+                        Enregistrer le nouveau mot de passe
                     </PrimaryButton>
-                </div>
-            </form>
-        </GuestLayout>
+                </form>
+            </div>
+        </AuthLayout>
     );
 }

--- a/resources/js/Pages/Auth/VerifyEmail.jsx
+++ b/resources/js/Pages/Auth/VerifyEmail.jsx
@@ -1,5 +1,5 @@
 import PrimaryButton from '@/Components/PrimaryButton';
-import GuestLayout from '@/Layouts/GuestLayout';
+import AuthLayout from '@/Layouts/AuthLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
 
 export default function VerifyEmail({ status }) {
@@ -11,40 +11,68 @@ export default function VerifyEmail({ status }) {
         post(route('verification.send'));
     };
 
+    const asideContent = (
+        <div className="flex flex-col items-center text-center text-white">
+            <img
+                src="/images/loup-blanc.png"
+                alt="Illustration d'un loup"
+                className="w-full max-w-sm"
+            />
+
+            <p className="mt-10 max-w-sm text-lg text-white/80">
+                Validez votre adresse mail pour débloquer l'ensemble des
+                fonctionnalités de Totem Mind.
+            </p>
+        </div>
+    );
+
     return (
-        <GuestLayout>
-            <Head title="Email Verification" />
+        <AuthLayout
+            aside={asideContent}
+            asideClassName="bg-brand-ocean"
+            backgroundClassName="bg-brand-midnight"
+            footerVariant="light"
+        >
+            <Head title="Vérification de l’adresse mail" />
 
-            <div className="mb-4 text-sm text-gray-600">
-                Thanks for signing up! Before getting started, could you verify
-                your email address by clicking on the link we just emailed to
-                you? If you didn't receive the email, we will gladly send you
-                another.
-            </div>
-
-            {status === 'verification-link-sent' && (
-                <div className="mb-4 text-sm font-medium text-green-600">
-                    A new verification link has been sent to the email address
-                    you provided during registration.
+            <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/20 backdrop-blur">
+                <div className="text-center">
+                    <h1 className="text-4xl font-semibold text-white">
+                        Vérifiez votre adresse mail
+                    </h1>
+                    <p className="mt-4 text-sm text-white/70">
+                        Cliquez sur le lien reçu par mail pour confirmer votre
+                        compte. Vous n'avez rien reçu ? Envoyez un nouveau lien
+                        en un clic.
+                    </p>
                 </div>
-            )}
 
-            <form onSubmit={submit}>
-                <div className="mt-4 flex items-center justify-between">
-                    <PrimaryButton disabled={processing}>
-                        Resend Verification Email
+                {status === 'verification-link-sent' && (
+                    <div className="mt-6 rounded-full bg-emerald-400/20 px-6 py-3 text-center text-sm font-semibold text-emerald-100">
+                        Un nouveau lien de vérification vient d'être envoyé à
+                        votre adresse mail.
+                    </div>
+                )}
+
+                <form className="mt-10 space-y-6" onSubmit={submit}>
+                    <PrimaryButton
+                        disabled={processing}
+                        variant="brand"
+                        className="w-full"
+                    >
+                        Renvoyer l’email de vérification
                     </PrimaryButton>
 
                     <Link
                         href={route('logout')}
                         method="post"
                         as="button"
-                        className="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        className="w-full rounded-full border border-white/40 px-5 py-3 text-center text-sm font-semibold text-white transition hover:border-white hover:bg-white/10"
                     >
-                        Log Out
+                        Se déconnecter
                     </Link>
-                </div>
-            </form>
-        </GuestLayout>
+                </form>
+            </div>
+        </AuthLayout>
     );
 }

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -16,7 +16,8 @@ Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredUserController::class, 'create'])
         ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+    Route::post('register', [RegisteredUserController::class, 'store'])
+        ->middleware('throttle:'.config('fortify.limiters.register.key', 'register'));
 
     Route::get('inscription-terminee', function () {
         return Inertia::render('Auth/RegistrationComplete');
@@ -25,7 +26,8 @@ Route::middleware('guest')->group(function () {
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
         ->name('login');
 
-    Route::post('login', [AuthenticatedSessionController::class, 'store']);
+    Route::post('login', [AuthenticatedSessionController::class, 'store'])
+        ->middleware('throttle:'.config('fortify.limiters.login.key', 'login'));
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
         ->name('password.request');

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -21,11 +21,18 @@ class RegistrationTest extends TestCase
         $response = $this->post('/register', [
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'birthdate' => now()->subYears(20)->toDateString(),
             'password' => 'password',
             'password_confirmation' => 'password',
+            'captcha' => true,
         ]);
 
-        $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('register.complete'));
+        $this->assertGuest();
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'birthdate' => now()->subYears(20)->toDateString(),
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- add Jetstream and Fortify infrastructure with service providers, custom namespaces, and configuration to drive the Inertia-powered auth views and enforce rate limiting
- harden authentication by introducing a dedicated registration action with age and captcha validation, persisting birthdates, and throttling login/registration requests
- restyle all auth Inertia pages with the new AuthLayout-driven branding and update the registration feature test for the revised workflow

## Testing
- `composer dump-autoload --no-scripts`
- `php artisan test` *(fails: missing framework dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced578dfa883308bc91ca1190df807