### PR TITLE
Ignore Fortify default routes

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,11 +7,14 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        Fortify::ignoreRoutes();
+
         $this->configureRateLimiting();
     }
 


### PR DESCRIPTION
## Summary
- call `Fortify::ignoreRoutes()` during Fortify service provider boot to prevent Laravel Fortify from registering its default routes when custom throttling configuration is used

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cee06504888330b02a8094bd4ee123