### PR TITLE
Ignore Fortify default routes

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,9 +7,15 @@ use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        Fortify::ignoreRoutes();
+    }
+
     public function boot(): void
     {
         $this->configureRateLimiting();


### PR DESCRIPTION
## Summary
- call `Fortify::ignoreRoutes()` during the Fortify service provider registration phase so default Fortify routes are skipped before their throttling middleware is resolved from configuration arrays

## Testing
- php artisan route:list *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cee06504888330b02a8094bd4ee123