### PR TITLE
Add account validation success page

### DIFF
--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,13 +15,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+            return redirect()->route('verification.success');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        return redirect()->route('verification.success');
     }
 }

--- a/resources/js/Pages/Auth/AccountValidated.jsx
+++ b/resources/js/Pages/Auth/AccountValidated.jsx
@@ -1,0 +1,50 @@
+import AuthLayout from '@/Layouts/AuthLayout';
+import { Head, Link } from '@inertiajs/react';
+
+export default function AccountValidated() {
+    return (
+        <AuthLayout
+            backgroundClassName="bg-brand-midnight"
+            footerVariant="light"
+            contentWrapperClassName="flex flex-col items-center text-center text-white"
+            showLogo
+        >
+            <Head title="Compte validé" />
+
+            <img
+                src="/images/renard-blanc.png"
+                alt="Illustration d'un renard"
+                className="w-full max-w-lg"
+            />
+
+            <div className="mt-16 flex w-full max-w-3xl items-center gap-8">
+                <span
+                    aria-hidden="true"
+                    className="h-px flex-1 bg-white/30"
+                ></span>
+                <h1 className="flex-shrink-0 font-serif text-5xl text-white">
+                    Compte validé !
+                </h1>
+                <span
+                    aria-hidden="true"
+                    className="h-px flex-1 bg-white/30"
+                ></span>
+            </div>
+
+            <p className="mt-12 text-lg text-white/80">
+                Votre compte a été validé !
+            </p>
+
+            <p className="mt-6 max-w-2xl text-base text-white/70">
+                Vous pouvez maintenant démarrer vos sondages rémunérés en vous{' '}
+                <Link
+                    href={route('login')}
+                    className="font-semibold text-brand-sand underline decoration-brand-sand/40 decoration-2 underline-offset-4 transition-colors duration-200 hover:text-white hover:decoration-white/60"
+                >
+                    connectant sur cette page
+                </Link>
+                .
+            </p>
+        </AuthLayout>
+    );
+}

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -68,3 +68,7 @@ Route::middleware('auth')->group(function () {
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
 });
+
+Route::get('compte-valide', function () {
+    return Inertia::render('Auth/AccountValidated');
+})->name('verification.success');


### PR DESCRIPTION
## Summary
- add a dedicated Inertia page for the “Compte validé” confirmation design
- expose the new page through a named route accessible after verification
- redirect the email verification flow to the confirmation page once the address is validated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d05b98c48483309a4db9bdeb976eb2