### PR TITLE
Adjust auth pages logo placement and login colors

### DIFF
--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -1,3 +1,4 @@
+import ApplicationLogo from '@/Components/ApplicationLogo';
 import Checkbox from '@/Components/Checkbox';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
@@ -44,11 +45,16 @@ export default function Login({ status, canResetPassword, canRegister }) {
     return (
         <AuthLayout
             aside={asideContent}
-            asideClassName="bg-brand-ocean"
-            backgroundClassName="bg-brand-midnight"
+            asideClassName="bg-brand-midnight"
+            backgroundClassName="bg-brand-ocean"
             footerVariant="light"
+            showLogo={false}
         >
             <Head title="Connexion" />
+
+            <div className="mb-10 mt-12 flex justify-start">
+                <ApplicationLogo className="h-16 w-auto" />
+            </div>
 
             <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/20 backdrop-blur">
                 <div className="text-center">

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -1,3 +1,4 @@
+import ApplicationLogo from '@/Components/ApplicationLogo';
 import Checkbox from '@/Components/Checkbox';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
@@ -121,8 +122,13 @@ export default function Register() {
             aside={asideContent}
             asideClassName="bg-brand-midnight"
             footerVariant="light"
+            showLogo={false}
         >
             <Head title="Inscription" />
+
+            <div className="mb-10 mt-12 flex justify-start">
+                <ApplicationLogo className="h-16 w-auto" />
+            </div>
 
             <div className="rounded-[2.5rem] bg-white/10 p-8 shadow-2xl shadow-black/20 backdrop-blur">
                 <div className="text-center">


### PR DESCRIPTION
## Summary
- place the Totem Mind logo directly within the login and registration forms and hide the centered header logo
- swap the login layout colors so the main panel and illustration sides match the intended design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06bb829e083309fc0a918d6aab6fe