### PR TITLE
Add global footer across application layouts

### DIFF
--- a/resources/js/Components/SiteFooter.jsx
+++ b/resources/js/Components/SiteFooter.jsx
@@ -1,17 +1,44 @@
 const variantStyles = {
-    light: 'border-white/20 text-white/70',
-    dark: 'border-slate-200 text-slate-600',
+    light: {
+        container: 'border-white/10 bg-brand-midnight text-white/80',
+        label: 'text-white',
+        link: 'text-white/80 hover:text-white',
+    },
+    dark: {
+        container: 'border-slate-200 bg-white text-slate-600',
+        label: 'text-brand-midnight',
+        link: 'text-slate-600 hover:text-brand-ocean',
+    },
 };
 
+const footerLinks = [
+    { label: 'CGU', href: '#' },
+    { label: 'Politique de confidentialité', href: '#' },
+    { label: 'Contact', href: '#' },
+];
+
 export default function SiteFooter({ className = '', variant = 'light' }) {
-    const year = new Date().getFullYear();
-    const resolvedVariant = variantStyles[variant] ?? variantStyles.light;
+    const { container, label, link } = variantStyles[variant] ?? variantStyles.light;
 
     return (
         <footer
-            className={`mt-auto w-full border-t px-6 py-6 text-center text-xs uppercase tracking-[0.3em] ${resolvedVariant} ${className}`.trim()}
+            className={`mt-auto w-full border-t px-6 py-6 text-sm ${container} ${className}`.trim()}
         >
-            © {year} Totem Mind. Tous droits réservés.
+            <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-6 gap-y-2 text-center">
+                <span className={`font-semibold ${label}`.trim()}>
+                    Totem Mind © 2025
+                </span>
+
+                {footerLinks.map((footerLink) => (
+                    <a
+                        key={footerLink.label}
+                        href={footerLink.href}
+                        className={`transition-colors ${link}`.trim()}
+                    >
+                        {footerLink.label}
+                    </a>
+                ))}
+            </div>
         </footer>
     );
 }

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -2,6 +2,7 @@ import ApplicationLogo from '@/Components/ApplicationLogo';
 import Dropdown from '@/Components/Dropdown';
 import NavLink from '@/Components/NavLink';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
+import SiteFooter from '@/Components/SiteFooter';
 import { Link, usePage } from '@inertiajs/react';
 import { useState } from 'react';
 
@@ -12,7 +13,7 @@ export default function AuthenticatedLayout({ header, children }) {
         useState(false);
 
     return (
-        <div className="min-h-screen bg-gray-100">
+        <div className="flex min-h-screen flex-col bg-gray-100">
             <nav className="border-b border-gray-100 bg-white">
                 <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                     <div className="flex h-16 justify-between">
@@ -170,7 +171,9 @@ export default function AuthenticatedLayout({ header, children }) {
                 </header>
             )}
 
-            <main>{children}</main>
+            <main className="flex-1">{children}</main>
+
+            <SiteFooter variant="dark" />
         </div>
     );
 }

--- a/resources/js/Layouts/GuestLayout.jsx
+++ b/resources/js/Layouts/GuestLayout.jsx
@@ -1,18 +1,23 @@
 import ApplicationLogo from '@/Components/ApplicationLogo';
+import SiteFooter from '@/Components/SiteFooter';
 import { Link } from '@inertiajs/react';
 
 export default function GuestLayout({ children }) {
     return (
-        <div className="flex min-h-screen flex-col items-center bg-gray-100 pt-6 sm:justify-center sm:pt-0">
-            <div>
-                <Link href="/">
-                    <ApplicationLogo className="h-20 w-20 fill-current text-gray-500" />
-                </Link>
-            </div>
+        <div className="flex min-h-screen flex-col bg-gray-100">
+            <main className="flex w-full flex-1 flex-col items-center pt-6 sm:justify-center sm:pt-0">
+                <div>
+                    <Link href="/">
+                        <ApplicationLogo className="h-20 w-20 fill-current text-gray-500" />
+                    </Link>
+                </div>
 
-            <div className="mt-6 w-full overflow-hidden bg-white px-6 py-4 shadow-md sm:max-w-md sm:rounded-lg">
-                {children}
-            </div>
+                <div className="mt-6 w-full overflow-hidden bg-white px-6 py-4 shadow-md sm:max-w-md sm:rounded-lg">
+                    {children}
+                </div>
+            </main>
+
+            <SiteFooter variant="dark" />
         </div>
     );
 }

--- a/resources/js/Pages/Welcome.jsx
+++ b/resources/js/Pages/Welcome.jsx
@@ -1,4 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
+import SiteFooter from '@/Components/SiteFooter';
 
 export default function Welcome({ auth, laravelVersion, phpVersion }) {
     const handleImageError = () => {
@@ -15,13 +16,13 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
     return (
         <>
             <Head title="Welcome" />
-            <div className="bg-gray-50 text-black/50 dark:bg-black dark:text-white/50">
-                <img
-                    id="background"
-                    className="absolute -left-20 top-0 max-w-[877px]"
-                    src="https://laravel.com/assets/img/welcome/background.svg"
-                />
-                <div className="relative flex min-h-screen flex-col items-center justify-center selection:bg-[#FF2D20] selection:text-white">
+            <div className="flex min-h-screen flex-col bg-gray-50 text-black/50 dark:bg-black dark:text-white/50">
+                <div className="relative flex flex-1 flex-col items-center justify-center selection:bg-[#FF2D20] selection:text-white">
+                    <img
+                        id="background"
+                        className="absolute -left-20 top-0 max-w-[877px]"
+                        src="https://laravel.com/assets/img/welcome/background.svg"
+                    />
                     <div className="relative w-full max-w-2xl px-6 lg:max-w-7xl">
                         <header className="grid grid-cols-2 items-center gap-2 py-10 lg:grid-cols-3">
                             <div className="flex lg:col-start-2 lg:justify-center">
@@ -355,6 +356,8 @@ export default function Welcome({ auth, laravelVersion, phpVersion }) {
                         </footer>
                     </div>
                 </div>
+
+                <SiteFooter variant="dark" />
             </div>
         </>
     );


### PR DESCRIPTION
## Summary
- restyle the SiteFooter component to match the new Totem Mind footer content and styling
- attach the shared footer to the authenticated and guest layouts so every page shows it
- add the footer to the Welcome page to ensure non-layout content also has the global footer

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d06c0497ec83308a3a231956e08891