### PR TITLE
Add French email notification copy

### DIFF
--- a/lang/fr/emails.php
+++ b/lang/fr/emails.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'validation' => [
+        'subject' => 'Validation de votre compte',
+        'greeting' => 'Bonjour !',
+        'intro' => 'Vous venez de créer un compte sur TotemMind.app.',
+        'instruction' => 'Pour accéder aux sondages rémunérés, veuillez valider votre compte en cliquant sur le lien ci-dessous :',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'welcome' => [
+        'subject' => 'Bienvenue sur TotemMind.app',
+        'intro' => 'Bravo, votre compte sur TotemMind.app vient d\'être validé !',
+        'instruction' => 'Vous pouvez dès maintenant vous connecter avec vos identifiants de connexion choisis lors de l\'inscription en cliquant sur le lien ci-dessous :',
+        'cta' => 'Se connecter (dirige vers l\'url page connexion)',
+        'details' => 'Chaque jour, une dizaine de sondages rémunérés sera disponible et vous pourrez demander le retrait vers Paypal à partir de 5€.',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'password_reset_request' => [
+        'subject' => 'Réinitialisation du mot de passe',
+        'greeting' => 'Bonjour,',
+        'intro' => 'Vous avez demandé à réinitialiser votre mot de passe sur TotemMind.app.',
+        'instruction' => 'Pour réaliser la réinitialisation, veuillez cliquer sur le lien ci-dessous :',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'password_reset_confirmation' => [
+        'subject' => 'Réinitialisation du mot de passe',
+        'greeting' => 'Bonjour,',
+        'intro' => 'Votre mot de passe sur TotemMind.app vient d\'être réinitialisé.',
+        'instruction' => 'Vous pouvez dès à présent vous connecter avec votre nouveau mot de passe en cliquant sur le lien ci-dessous :',
+        'cta' => 'Se connecter (dirige vers l\'url page connexion)',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+];


### PR DESCRIPTION
## Summary
- add French copy for validation, welcome, and password reset email notifications

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4fcefcacc833082c646654c0ac376