### PR TITLE
Apply branded styling to notification emails

### DIFF
--- a/app/Listeners/SendPasswordResetSuccessNotification.php
+++ b/app/Listeners/SendPasswordResetSuccessNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Notifications\PasswordResetSuccess;
+use Illuminate\Auth\Events\PasswordReset;
+
+class SendPasswordResetSuccessNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(PasswordReset $event): void
+    {
+        $event->user->notify(new PasswordResetSuccess());
+    }
+}

--- a/app/Listeners/SendWelcomeNotification.php
+++ b/app/Listeners/SendWelcomeNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Notifications\WelcomeNotification;
+use Illuminate\Auth\Events\Verified;
+
+class SendWelcomeNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(Verified $event): void
+    {
+        $event->user->notify(new WelcomeNotification());
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Notifications\ResetPassword as ResetPasswordNotification;
+use App\Notifications\VerifyEmail as VerifyEmailNotification;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -47,5 +49,21 @@ class User extends Authenticatable implements MustVerifyEmail
             'birthdate' => 'date',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Send the email verification notification.
+     */
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new VerifyEmailNotification());
+    }
+
+    /**
+     * Send the password reset notification.
+     */
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify(new ResetPasswordNotification($token));
     }
 }

--- a/app/Notifications/PasswordResetSuccess.php
+++ b/app/Notifications/PasswordResetSuccess.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PasswordResetSuccess extends Notification
+{
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $data = [
+            'subject' => trans('emails.password_reset_confirmation.subject'),
+            'greeting' => trans('emails.password_reset_confirmation.greeting'),
+            'lines' => [
+                trans('emails.password_reset_confirmation.intro'),
+                trans('emails.password_reset_confirmation.instruction'),
+            ],
+            'cta' => [
+                'label' => trans('emails.password_reset_confirmation.cta'),
+                'url' => route('login'),
+            ],
+            'salutation' => trans('emails.password_reset_confirmation.salutation'),
+            'signature' => trans('emails.password_reset_confirmation.signature'),
+        ];
+
+        return (new MailMessage())
+            ->subject($data['subject'])
+            ->view('emails.brand', $data);
+    }
+}

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPassword extends ResetPasswordNotification
+{
+    /**
+     * Build the mail representation of the notification.
+     */
+    protected function buildMailMessage($url): MailMessage
+    {
+        $data = [
+            'subject' => trans('emails.password_reset_request.subject'),
+            'greeting' => trans('emails.password_reset_request.greeting'),
+            'lines' => [
+                trans('emails.password_reset_request.intro'),
+                trans('emails.password_reset_request.instruction'),
+            ],
+            'cta' => [
+                'label' => trans('emails.password_reset_request.cta'),
+                'url' => $url,
+            ],
+            'salutation' => trans('emails.password_reset_request.salutation'),
+            'signature' => trans('emails.password_reset_request.signature'),
+        ];
+
+        return (new MailMessage())
+            ->subject($data['subject'])
+            ->view('emails.brand', $data);
+    }
+}

--- a/app/Notifications/VerifyEmail.php
+++ b/app/Notifications/VerifyEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail as VerifyEmailNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class VerifyEmail extends VerifyEmailNotification
+{
+    /**
+     * Build the mail representation of the notification.
+     */
+    protected function buildMailMessage($url): MailMessage
+    {
+        $data = [
+            'subject' => trans('emails.validation.subject'),
+            'greeting' => trans('emails.validation.greeting'),
+            'lines' => [
+                trans('emails.validation.intro'),
+                trans('emails.validation.instruction'),
+            ],
+            'cta' => [
+                'label' => trans('emails.validation.cta'),
+                'url' => $url,
+            ],
+            'salutation' => trans('emails.validation.salutation'),
+            'signature' => trans('emails.validation.signature'),
+        ];
+
+        return (new MailMessage())
+            ->subject($data['subject'])
+            ->view('emails.brand', $data);
+    }
+}

--- a/app/Notifications/WelcomeNotification.php
+++ b/app/Notifications/WelcomeNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class WelcomeNotification extends Notification
+{
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $data = [
+            'subject' => trans('emails.welcome.subject'),
+            'lines' => [
+                trans('emails.welcome.intro'),
+                trans('emails.welcome.instruction'),
+                trans('emails.welcome.details'),
+            ],
+            'cta' => [
+                'label' => trans('emails.welcome.cta'),
+                'url' => route('login'),
+            ],
+            'salutation' => trans('emails.welcome.salutation'),
+            'signature' => trans('emails.welcome.signature'),
+        ];
+
+        return (new MailMessage())
+            ->subject($data['subject'])
+            ->view('emails.brand', $data);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,11 @@
 
 namespace App\Providers;
 
+use App\Listeners\SendPasswordResetSuccessNotification;
+use App\Listeners\SendWelcomeNotification;
+use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -16,6 +20,12 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        Verified::class => [
+            SendWelcomeNotification::class,
+        ],
+        PasswordReset::class => [
+            SendPasswordResetSuccessNotification::class,
         ],
     ];
 }

--- a/lang/fr/emails.php
+++ b/lang/fr/emails.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    'validation' => [
+        'subject' => 'Validation de votre compte',
+        'greeting' => 'Bonjour !',
+        'intro' => 'Vous venez de créer un compte sur TotemMind.app.',
+        'instruction' => 'Pour accéder aux sondages rémunérés, veuillez valider votre compte en cliquant sur le lien ci-dessous :',
+        'cta' => 'Valider mon compte',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'welcome' => [
+        'subject' => 'Bienvenue sur TotemMind.app',
+        'intro' => 'Bravo, votre compte sur TotemMind.app vient d\'être validé !',
+        'instruction' => 'Vous pouvez dès maintenant vous connecter avec vos identifiants de connexion choisis lors de l\'inscription en cliquant sur le lien ci-dessous :',
+        'cta' => 'Se connecter',
+        'details' => 'Chaque jour, une dizaine de sondages rémunérés sera disponible et vous pourrez demander le retrait vers Paypal à partir de 5€.',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'password_reset_request' => [
+        'subject' => 'Réinitialisation du mot de passe',
+        'greeting' => 'Bonjour,',
+        'intro' => 'Vous avez demandé à réinitialiser votre mot de passe sur TotemMind.app.',
+        'instruction' => 'Pour réaliser la réinitialisation, veuillez cliquer sur le lien ci-dessous :',
+        'cta' => 'Réinitialiser mon mot de passe',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+
+    'password_reset_confirmation' => [
+        'subject' => 'Réinitialisation du mot de passe',
+        'greeting' => 'Bonjour,',
+        'intro' => 'Votre mot de passe sur TotemMind.app vient d\'être réinitialisé.',
+        'instruction' => 'Vous pouvez dès à présent vous connecter avec votre nouveau mot de passe en cliquant sur le lien ci-dessous :',
+        'cta' => 'Se connecter',
+        'salutation' => 'À très bientôt sur Totem Mind !',
+        'signature' => 'TotemMind.app',
+    ],
+];

--- a/resources/views/emails/brand.blade.php
+++ b/resources/views/emails/brand.blade.php
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{{ $subject ?? config('app.name') }}</title>
+    </head>
+    <body style="margin:0;padding:0;background-color:#f4f1ea;">
+        @php
+            $fontFamily = '"Open Sans", Arial, sans-serif';
+            $serifFont = '"Playfair Display", Georgia, serif';
+            $lines = $lines ?? [];
+            $greeting = $greeting ?? null;
+            $salutation = $salutation ?? null;
+            $signature = $signature ?? null;
+            $cta = $cta ?? null;
+            $preheader = $preheader ?? ($lines[0] ?? '');
+        @endphp
+
+        <div style="display:none;max-height:0;overflow:hidden;opacity:0;">{{ $preheader }}</div>
+
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f1ea;">
+            <tr>
+                <td align="center" style="padding:32px 16px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 18px 45px rgba(29,38,61,0.12);">
+                        <tr>
+                            <td style="background-color:#1d263d;padding:32px 32px 28px;text-align:center;">
+                                <span style="display:block;color:#f4f1ea;font-family:{{ $serifFont }};font-size:26px;letter-spacing:0.35em;text-transform:uppercase;">Totem Mind</span>
+                                <span style="display:block;margin-top:12px;color:#e0e1dc;font-family:{{ $fontFamily }};font-size:14px;letter-spacing:0.24em;text-transform:uppercase;">Sondages rémunérés</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="padding:40px 32px 32px;font-family:{{ $fontFamily }};color:#1d263d;background-color:#ffffff;">
+                                @if($greeting)
+                                    <p style="margin:0 0 16px;font-size:18px;font-weight:600;">{{ $greeting }}</p>
+                                @endif
+
+                                @foreach($lines as $line)
+                                    <p style="margin:0 0 18px;font-size:16px;line-height:1.6;color:#415a78;">{{ $line }}</p>
+                                @endforeach
+
+                                @if($cta && ($cta['label'] ?? null) && ($cta['url'] ?? null))
+                                    <p style="margin:24px 0 32px;">
+                                        <a href="{{ $cta['url'] }}" style="display:inline-block;padding:16px 32px;background-color:#415a78;color:#f4f1ea;text-decoration:none;border-radius:999px;font-weight:700;font-size:16px;letter-spacing:0.08em;text-transform:uppercase;">
+                                            {{ $cta['label'] }}
+                                        </a>
+                                    </p>
+                                @endif
+
+                                @if($salutation || $signature)
+                                    <p style="margin:32px 0 0;font-size:16px;line-height:1.6;color:#415a78;">
+                                        @if($salutation)
+                                            {{ $salutation }}<br>
+                                        @endif
+                                        @if($signature)
+                                            <span style="font-weight:600;color:#1d263d;">{{ $signature }}</span>
+                                        @endif
+                                    </p>
+                                @endif
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="background-color:#e0e1dc;padding:20px 32px;text-align:center;font-family:{{ $fontFamily }};color:#1d263d;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;">
+                                © {{ date('Y') }} TotemMind.app · Tous droits réservés
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- introduce a reusable Blade layout that applies Totem Mind brand colors and typography to outgoing emails
- render verification, welcome, and password reset notifications through the new template with localized copy and CTA details

## Testing
- not run (vendor directory missing; installing dependencies requires a GitHub token)


------
https://chatgpt.com/codex/tasks/task_e_68d4fcefcacc833082c646654c0ac376