### PR TITLE
Restyle dashboard layout to match new design

### DIFF
--- a/resources/js/Layouts/SurveyLayout.jsx
+++ b/resources/js/Layouts/SurveyLayout.jsx
@@ -13,17 +13,16 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
             href: route('dashboard'),
             type: 'link',
         },
-        { key: 'welcome', label: '1€', type: 'placeholder' },
         { key: 'payment', label: 'Paiement', type: 'placeholder' },
         { key: 'settings', label: 'Paramètres', type: 'placeholder' },
     ];
 
     return (
-        <div className="flex min-h-screen flex-col bg-[#212c39] font-sans text-white">
+        <div className="flex min-h-screen flex-col bg-[#071522] text-white">
             <div className="flex flex-1 flex-col lg:flex-row">
-                <aside className="w-full bg-[#212c39] px-8 py-10 lg:w-80">
+                <aside className="w-full bg-[#081b2e] px-8 py-10 lg:w-80">
                     <div className="flex h-full flex-col">
-                        <Link href="/" className="flex items-center gap-4">
+                        <Link href="/" className="flex items-center gap-4 text-white">
                             <ApplicationLogo className="h-14 w-auto" />
 
                             <div className="flex flex-col">
@@ -36,17 +35,18 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                             </div>
                         </Link>
 
-                        <div className="mt-10 space-y-1 text-white/70">
-                            <p className="text-[0.65rem] uppercase tracking-[0.45em] text-white/40">
-                                Bonjour
-                            </p>
-                            <p className="text-lg font-semibold text-white">
-                                {user?.name}
-                            </p>
-                            <p className="text-xs text-white/50">{user?.email}</p>
+                        <div className="mt-10 flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
+                            <div>
+                                <p className="text-[0.65rem] uppercase tracking-[0.45em] text-white/50">Bonjour</p>
+                                <p className="text-lg font-semibold text-white">{user?.name}</p>
+                                <p className="text-xs text-white/50">{user?.email}</p>
+                            </div>
+                            <span className="rounded-full bg-white px-4 py-1 text-sm font-semibold uppercase tracking-[0.3em] text-[#081b2e]">
+                                1 €
+                            </span>
                         </div>
 
-                        <nav className="mt-12 flex flex-col gap-2">
+                        <nav className="mt-12 flex flex-col gap-3">
                             {navigation.map((item) => {
                                 const isActive = item.key === activeItem;
 
@@ -55,10 +55,10 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                                         <Link
                                             key={item.key}
                                             href={item.href}
-                                            className={`flex w-full items-center justify-between rounded-xl px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] transition-colors duration-200 ${
+                                            className={`flex w-full items-center justify-between rounded-2xl px-5 py-4 text-sm font-semibold uppercase tracking-[0.35em] transition-colors duration-200 ${
                                                 isActive
-                                                    ? 'bg-[#e0e1dc] text-[#212c39] shadow-lg shadow-black/10'
-                                                    : 'bg-white/5 text-white/80 hover:bg-[#e0e1dc] hover:text-[#212c39]'
+                                                    ? 'bg-[#f1f5f9] text-[#081b2e] shadow-xl shadow-black/30'
+                                                    : 'bg-white/5 text-white/80 hover:bg-white/10'
                                             }`.trim()}
                                         >
                                             {item.label}
@@ -70,7 +70,7 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                                     <span
                                         key={item.key}
                                         aria-disabled="true"
-                                        className="flex w-full items-center justify-between rounded-xl bg-white/5 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white/30"
+                                        className="flex w-full items-center justify-between rounded-2xl bg-white/5 px-5 py-4 text-sm font-semibold uppercase tracking-[0.35em] text-white/30"
                                     >
                                         {item.label}
                                     </span>
@@ -84,7 +84,7 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                                 method="post"
                                 as="button"
                                 type="button"
-                                className="inline-flex w-full items-center justify-center rounded-xl bg-[#e0e1dc] px-5 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-[#212c39] shadow-lg shadow-black/10 transition-colors duration-200 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/30"
+                                className="inline-flex w-full items-center justify-center rounded-2xl bg-white px-5 py-4 text-sm font-semibold uppercase tracking-[0.3em] text-[#081b2e] shadow-xl shadow-black/30 transition-colors duration-200 hover:bg-[#f1f5f9] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/30"
                             >
                                 Déconnexion
                             </Link>
@@ -92,7 +92,7 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                     </div>
                 </aside>
 
-                <main className="flex flex-1 items-stretch bg-[#e0e1dc] text-[#212c39]">
+                <main className="flex flex-1 items-stretch bg-gradient-to-br from-[#0c2238] via-[#112c46] to-[#1b3f62] text-[#081b2e]">
                     {children}
                 </main>
             </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -6,89 +6,55 @@ export default function Dashboard() {
         <SurveyLayout activeItem="surveys">
             <Head title="Sondages rémunérés" />
 
-            <div className="flex w-full flex-col">
-                <div className="mx-auto w-full max-w-5xl px-6 py-12 lg:px-16 lg:py-16">
-                    <div className="flex flex-col gap-10">
-                        <header className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+            <div className="relative flex w-full flex-col overflow-hidden px-6 py-12 sm:px-10 lg:px-16 lg:py-16">
+                <div className="absolute inset-0">
+                    <div className="absolute inset-0 bg-white/5" aria-hidden="true" />
+                    <div className="absolute -top-24 left-10 h-64 w-64 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
+                    <div className="absolute bottom-0 right-12 h-72 w-72 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
+                </div>
+
+                <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col">
+                    <div className="relative overflow-hidden rounded-3xl border border-white/20 bg-white/95 px-8 py-10 text-[#081b2e] shadow-[0_40px_80px_-40px_rgba(4,15,28,0.45)] backdrop-blur">
+                        <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
                             <div className="max-w-2xl">
-                                <h1 className="font-serif text-4xl text-[#1f2d3c]">
+                                <p className="text-sm uppercase tracking-[0.35em] text-[#0f2a44]/60">
+                                    Totem Mind
+                                </p>
+                                <h1 className="mt-4 font-serif text-4xl text-[#0f2a44]">
                                     Sondages rémunérés
                                 </h1>
-                                <p className="mt-4 text-base text-[#1f2d3c]/80">
-                                    Certains sondages vous donnent des récompenses même si vous n'êtes
-                                    pas sélectionné(e) !
+                                <p className="mt-4 max-w-xl text-base text-[#0f2a44]/75">
+                                    Certains sondages vous donnent des récompenses même si vous n'êtes pas sélectionné(e) !
                                 </p>
                             </div>
+                        </div>
 
-                            <div className="rounded-3xl bg-white/80 px-8 py-6 text-center text-[#212c39] shadow-lg shadow-black/5">
-                                <p className="text-xs uppercase tracking-[0.45em] text-[#212c39]/60">
-                                    Cadeau de bienvenue
-                                </p>
-                                <p className="mt-3 text-4xl font-bold text-[#212c39]">+1€</p>
-                                <p className="mt-2 text-sm text-[#212c39]/70">
-                                    Chaque nouvel explorateur reçoit automatiquement 1€ dès son
-                                    inscription.
-                                </p>
-                                <button
-                                    type="button"
-                                    className="mt-5 inline-flex items-center justify-center rounded-full bg-[#e0e1dc] px-8 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-[#212c39] shadow-sm transition-transform duration-200 hover:scale-105 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#212c39]/30"
-                                >
-                                    Voir mes gains
-                                </button>
-                            </div>
-                        </header>
-
-                        <div className="rounded-3xl border border-dashed border-[#212c39]/30 bg-white/60 px-8 py-6 text-sm text-[#212c39]/70 shadow-inner shadow-black/5">
+                        <div className="mt-10 rounded-3xl border border-dashed border-[#0f2a44]/30 bg-white/80 px-6 py-6 text-sm italic text-[#0f2a44]/70">
                             (note développeur : ici, on mettra le script-code des sondages)
                         </div>
 
-                        <section className="flex flex-col items-center justify-center rounded-3xl bg-white px-10 py-16 text-center shadow-xl shadow-black/10">
-                            <div className="rounded-full bg-[#e0e1dc] p-6 shadow-inner shadow-black/5">
-                                <svg
-                                    viewBox="0 0 120 120"
-                                    aria-hidden="true"
-                                    className="h-20 w-20 text-[#415a78]"
-                                    fill="none"
-                                >
-                                    <path
-                                        d="M20 92h80"
-                                        stroke="currentColor"
-                                        strokeWidth="4"
-                                        strokeLinecap="round"
-                                    />
-                                    <path
-                                        d="M30 92l18-32 16 24 14-20 22 28"
-                                        stroke="currentColor"
-                                        strokeWidth="4"
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                    />
-                                    <circle cx="36" cy="28" r="4" fill="currentColor" />
-                                    <path
-                                        d="m74 18 3 6 6 3-6 3-3 6-3-6-6-3 6-3 3-6z"
-                                        fill="currentColor"
-                                        opacity="0.4"
-                                    />
-                                    <path
-                                        d="M54 46c4 2 7 5 8 10"
-                                        stroke="currentColor"
-                                        strokeWidth="3"
-                                        strokeLinecap="round"
-                                        opacity="0.6"
-                                    />
-                                </svg>
-                            </div>
+                        <div className="relative mt-12 flex flex-col items-center gap-8 text-center">
+                            <img
+                                src="/images/element-08.png"
+                                alt="Illustration décorative de Totem Mind"
+                                className="h-24 w-auto"
+                            />
 
-                            <p className="mt-10 max-w-3xl font-serif text-2xl leading-snug text-[#333333]">
-                                On dirait qu'il n'y a plus de sondages disponibles pour le moment,
-                                revenez dans quelques heures !
+                            <p className="max-w-3xl font-serif text-2xl leading-snug text-[#0f2a44]">
+                                On dirait qu'il n'y a plus de sondages disponibles pour le moment, revenez dans quelques heures !
                             </p>
-                            <p className="mt-4 max-w-2xl text-base text-[#212c39]/70">
-                                Patience, de nouvelles missions arrivent très vite. Activez vos
-                                notifications pour être averti dès qu'un nouveau sondage rémunéré est
-                                disponible.
+                            <p className="max-w-2xl text-base text-[#0f2a44]/70">
+                                Patience, de nouvelles missions arrivent très vite. Activez vos notifications pour être averti dès
+                                qu'un nouveau sondage rémunéré est disponible.
                             </p>
-                        </section>
+                        </div>
+
+                        <img
+                            src="/images/paysage-bleu.png"
+                            alt="Paysage bleu décoratif"
+                            className="pointer-events-none absolute bottom-0 right-0 w-[18rem] max-w-full translate-y-16 select-none opacity-90"
+                            aria-hidden="true"
+                        />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- refresh the survey layout sidebar with a darker gradient, prominent greeting, and 1 € badge
- rebuild the dashboard content to match the provided mock, including the new typography and section structure
- embed the "element-08" and "paysage-bleu" assets for the empty state illustration and background accent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d811b58b6483308704bebd8a6760a9