### PR TITLE
Refactor landing navbar for static pages

### DIFF
--- a/resources/js/Components/LandingNavbar.jsx
+++ b/resources/js/Components/LandingNavbar.jsx
@@ -1,0 +1,28 @@
+import { Link } from '@inertiajs/react';
+
+export default function LandingNavbar({
+    ctaHref,
+    ctaLabel = 'Accéder aux sondages',
+    headerClassName = '',
+    containerClassName = '',
+    logoClassName = 'h-10 w-auto',
+}) {
+    return (
+        <header className={`border-b border-white/10 bg-[#0b1a33]/80 ${headerClassName}`.trim()}>
+            <div className={`mx-auto flex h-20 w-full max-w-6xl items-center justify-between px-6 ${containerClassName}`.trim()}>
+                <Link href="/" className="flex items-center" aria-label="Totem Mind">
+                    <img src="/images/Logo-blanc.png" alt="Totem Mind" className={logoClassName} />
+                </Link>
+
+                {ctaHref ? (
+                    <Link
+                        href={ctaHref}
+                        className="text-sm font-semibold uppercase tracking-[0.45em] text-white transition hover:text-brand-ocean"
+                    >
+                        {ctaLabel}
+                    </Link>
+                ) : null}
+            </div>
+        </header>
+    );
+}

--- a/resources/js/Layouts/StaticPageLayout.jsx
+++ b/resources/js/Layouts/StaticPageLayout.jsx
@@ -1,33 +1,10 @@
-import ApplicationLogo from '@/Components/ApplicationLogo';
 import SiteFooter from '@/Components/SiteFooter';
-import { Link } from '@inertiajs/react';
+import LandingNavbar from '@/Components/LandingNavbar';
 
 export default function StaticPageLayout({ title, lead, children, contentClassName = '' }) {
     return (
         <div className="flex min-h-screen flex-col bg-brand-cream text-brand-midnight">
-            <header className="border-b border-brand-sand/70 bg-white/80 backdrop-blur">
-                <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-6">
-                    <Link href="/" className="flex items-center gap-4 text-brand-midnight">
-                        <ApplicationLogo className="h-14 w-auto" />
-
-                        <div className="flex flex-col">
-                            <span className="text-xs uppercase tracking-[0.4em] text-brand-ocean/70">
-                                Totem Mind
-                            </span>
-                            <span className="font-serif text-2xl text-brand-midnight">
-                                Univers des explorateurs
-                            </span>
-                        </div>
-                    </Link>
-
-                    <Link
-                        href={route('dashboard')}
-                        className="inline-flex items-center justify-center rounded-full border border-brand-ocean/20 bg-brand-midnight px-6 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white shadow-xl shadow-brand-midnight/20 transition-colors duration-200 hover:bg-brand-ocean focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-ocean/40"
-                    >
-                        Accéder aux sondages
-                    </Link>
-                </div>
-            </header>
+            <LandingNavbar ctaHref={route('dashboard')} />
 
             <main className="flex-1">
                 <div className="mx-auto w-full max-w-5xl px-6 py-16">

--- a/resources/js/Pages/Welcome.jsx
+++ b/resources/js/Pages/Welcome.jsx
@@ -1,5 +1,6 @@
 import { Head, Link } from '@inertiajs/react';
 import SiteFooter from '@/Components/SiteFooter';
+import LandingNavbar from '@/Components/LandingNavbar';
 
 const highlightSteps = [
     {
@@ -79,21 +80,7 @@ export default function Welcome({ auth }) {
         <>
             <Head title="Accueil" />
             <div className="flex min-h-screen flex-col bg-[#0b1a33] text-white">
-                <header className="border-b border-white/10 bg-[#0b1a33]/80">
-                    <div className="mx-auto flex h-20 w-full max-w-6xl items-center justify-between px-6">
-                        <Link href="/" className="flex items-center gap-2 text-white">
-                            <span className="text-xl font-semibold tracking-[0.6em]">TOTEM</span>
-                            <span className="-ml-3 text-sm font-light uppercase tracking-[0.5em]">mind</span>
-                        </Link>
-
-                        <Link
-                            href={ctaLink}
-                            className="text-sm font-semibold uppercase tracking-[0.45em] text-white transition hover:text-brand-ocean"
-                        >
-                            Accéder aux sondages
-                        </Link>
-                    </div>
-                </header>
+                <LandingNavbar ctaHref={ctaLink} />
 
                 <div className="relative isolate flex flex-1 items-center justify-center overflow-hidden">
                     <div className="absolute inset-0 opacity-40">


### PR DESCRIPTION
## Summary
- create a reusable landing navbar component that uses the white logo asset
- update the welcome page to consume the new navbar component
- switch static content pages to reuse the landing navbar for consistent branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9f895b8c8330ab2ebad55fa3b65d