### PR TITLE
Restyle dashboard to match original layout

### DIFF
--- a/resources/js/Layouts/SurveyLayout.jsx
+++ b/resources/js/Layouts/SurveyLayout.jsx
@@ -92,7 +92,7 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                     </div>
                 </aside>
 
-                <main className="flex flex-1 items-stretch bg-gradient-to-br from-[#0c2238] via-[#112c46] to-[#1b3f62] text-[#081b2e]">
+                <main className="relative flex flex-1 items-stretch bg-[#f6f3ec] text-[#081b2e]">
                     {children}
                 </main>
             </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -7,54 +7,35 @@ export default function Dashboard() {
             <Head title="Sondages rémunérés" />
 
             <div className="relative flex w-full flex-col overflow-hidden px-6 py-12 sm:px-10 lg:px-16 lg:py-16">
-                <div className="absolute inset-0">
-                    <div className="absolute inset-0 bg-white/5" aria-hidden="true" />
-                    <div className="absolute -top-24 left-10 h-64 w-64 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
-                    <div className="absolute bottom-0 right-12 h-72 w-72 rounded-full bg-white/10 blur-3xl" aria-hidden="true" />
-                </div>
+                <img
+                    src="/images/paysage-bleu.png"
+                    alt="Décor de Totem Mind"
+                    className="pointer-events-none absolute -top-6 right-6 w-52 max-w-full select-none opacity-30"
+                    aria-hidden="true"
+                />
 
-                <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col">
-                    <div className="relative overflow-hidden rounded-3xl border border-white/20 bg-white/95 px-8 py-10 text-[#081b2e] shadow-[0_40px_80px_-40px_rgba(4,15,28,0.45)] backdrop-blur">
-                        <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
-                            <div className="max-w-2xl">
-                                <p className="text-sm uppercase tracking-[0.35em] text-[#0f2a44]/60">
-                                    Totem Mind
-                                </p>
-                                <h1 className="mt-4 font-serif text-4xl text-[#0f2a44]">
-                                    Sondages rémunérés
-                                </h1>
-                                <p className="mt-4 max-w-xl text-base text-[#0f2a44]/75">
-                                    Certains sondages vous donnent des récompenses même si vous n'êtes pas sélectionné(e) !
-                                </p>
-                            </div>
-                        </div>
+                <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col gap-10 text-[#081b2e]">
+                    <div className="flex flex-col gap-4">
+                        <h1 className="text-4xl font-semibold text-[#081b2e]">Sondages rémunérés</h1>
+                        <p className="max-w-2xl text-base text-[#081b2e]/80">
+                            Certains sondages vous donnent des récompenses même si vous n'êtes pas sélectionné(e) !
+                        </p>
+                    </div>
 
-                        <div className="mt-10 rounded-3xl border border-dashed border-[#0f2a44]/30 bg-white/80 px-6 py-6 text-sm italic text-[#0f2a44]/70">
-                            (note développeur : ici, on mettra le script-code des sondages)
-                        </div>
+                    <div className="rounded-3xl border border-dashed border-[#081b2e]/20 bg-white/60 px-6 py-6 text-sm italic text-[#081b2e]/70">
+                        (note développeur : ici, on mettra le script-code des sondages)
+                    </div>
 
-                        <div className="relative mt-12 flex flex-col items-center gap-8 text-center">
-                            <img
-                                src="/images/element-08.png"
-                                alt="Illustration décorative de Totem Mind"
-                                className="h-24 w-auto"
-                            />
-
-                            <p className="max-w-3xl font-serif text-2xl leading-snug text-[#0f2a44]">
-                                On dirait qu'il n'y a plus de sondages disponibles pour le moment, revenez dans quelques heures !
-                            </p>
-                            <p className="max-w-2xl text-base text-[#0f2a44]/70">
-                                Patience, de nouvelles missions arrivent très vite. Activez vos notifications pour être averti dès
-                                qu'un nouveau sondage rémunéré est disponible.
-                            </p>
-                        </div>
-
+                    <div className="flex flex-1 flex-col items-center justify-center gap-8 text-center">
                         <img
-                            src="/images/paysage-bleu.png"
-                            alt="Paysage bleu décoratif"
-                            className="pointer-events-none absolute bottom-0 right-0 w-[18rem] max-w-full translate-y-16 select-none opacity-90"
-                            aria-hidden="true"
+                            src="/images/element-08.png"
+                            alt="Illustration décorative Totem Mind"
+                            className="h-24 w-auto"
                         />
+
+                        <p className="max-w-3xl text-2xl font-semibold leading-snug text-[#081b2e]">
+                            On dirait qu'il n'y a plus de sondages disponibles pour le moment, revenez dans quelques heures !
+                        </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- simplify the dashboard content structure to mirror the reference styling and copy
- adjust the survey layout background color so the dashboard area matches the light theme palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dba6b3e1d483309a210e2d0a395bf1