### PR TITLE
Update footer links and set login as home page

### DIFF
--- a/resources/js/Components/SiteFooter.jsx
+++ b/resources/js/Components/SiteFooter.jsx
@@ -1,5 +1,3 @@
-import { Link } from '@inertiajs/react';
-
 const variantStyles = {
     light: {
         container: 'border-white/10 bg-brand-midnight text-white/80',
@@ -14,9 +12,12 @@ const variantStyles = {
 };
 
 const footerLinks = [
-    { label: 'CGU', routeName: 'terms' },
-    { label: 'Politique de confidentialité', routeName: 'privacy' },
-    { label: 'Contact', routeName: 'contact' },
+    { label: 'CGU', href: 'https://totemmind.app/cgu-mentions-legales/' },
+    {
+        label: 'Politique de confidentialité',
+        href: 'https://totemmind.app/politique-de-confidentialite/',
+    },
+    { label: 'Contact', href: 'https://totemmind.app/contact/' },
 ];
 
 export default function SiteFooter({ className = '', variant = 'light' }) {
@@ -32,13 +33,13 @@ export default function SiteFooter({ className = '', variant = 'light' }) {
                 </span>
 
                 {footerLinks.map((footerLink) => (
-                    <Link
+                    <a
                         key={footerLink.label}
-                        href={route(footerLink.routeName)}
+                        href={footerLink.href}
                         className={`transition-colors ${link}`.trim()}
                     >
                         {footerLink.label}
-                    </Link>
+                    </a>
                 ))}
             </div>
         </footer>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -35,7 +35,7 @@ Route::middleware('guest')->group(function () use ($registerThrottle, $loginThro
         return Inertia::render('Auth/RegistrationComplete');
     })->name('register.complete');
 
-    Route::get('login', [AuthenticatedSessionController::class, 'create'])
+    Route::get('/', [AuthenticatedSessionController::class, 'create'])
         ->name('login');
 
     Route::post('login', [AuthenticatedSessionController::class, 'store'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,30 +1,8 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
-
-Route::get('/', function () {
-    return Inertia::render('Welcome', [
-        'canLogin' => Route::has('login'),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
-});
-
-Route::get('/cgu-mentions-legales', function () {
-    return Inertia::render('TermsAndLegal');
-})->name('terms');
-
-Route::get('/politique-de-confidentialite', function () {
-    return Inertia::render('PrivacyPolicy');
-})->name('privacy');
-
-Route::get('/contact', function () {
-    return Inertia::render('Contact');
-})->name('contact');
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- replace footer navigation with static links to the production policy, legal, and contact pages
- remove the unused legal/privacy/contact Inertia routes and drop the welcome page route in favour of the login screen
- expose the login view at the application root path

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b7917bc8330ab3ad076dcc17d29