### PR TITLE
Redirect authenticated users from home to dashboard

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -35,9 +35,6 @@ Route::middleware('guest')->group(function () use ($registerThrottle, $loginThro
         return Inertia::render('Auth/RegistrationComplete');
     })->name('register.complete');
 
-    Route::get('/', [AuthenticatedSessionController::class, 'create'])
-        ->name('login');
-
     Route::post('login', [AuthenticatedSessionController::class, 'store'])
         ->middleware('throttle:'.$loginThrottle);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,18 @@
 <?php
 
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\ProfileController;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+
+Route::get('/', function (Request $request, AuthenticatedSessionController $controller) {
+    if ($request->user()) {
+        return redirect()->route('dashboard');
+    }
+
+    return $controller->create($request);
+})->name('login');
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- render the login page at the root only for guests and redirect authenticated users to the dashboard
- remove the duplicate guest login GET route definition now handled by the home route

## Testing
- Not run (composer dependencies are not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd3e2108348330bb5b746deee537db