### PR TITLE
Fix login route to use /login endpoint

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,15 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-Route::get('/', function (Request $request, AuthenticatedSessionController $controller) {
+Route::get('/', function (Request $request) {
+    if ($request->user()) {
+        return redirect()->route('dashboard');
+    }
+
+    return redirect()->route('login');
+});
+
+Route::get('/login', function (Request $request, AuthenticatedSessionController $controller) {
     if ($request->user()) {
         return redirect()->route('dashboard');
     }


### PR DESCRIPTION
## Summary
- redirect root route to the named login route
- expose login form at /login so POST requests resolve to /login instead of /

## Testing
- php artisan route:list --name=login *(fails: missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dd76a4e2348330ab456c3fbad4edef