### PR TITLE
Update login page styling and layout

### DIFF
--- a/resources/js/Components/PrimaryButton.jsx
+++ b/resources/js/Components/PrimaryButton.jsx
@@ -2,7 +2,7 @@ const baseClasses = {
     default:
         'inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 active:bg-gray-900',
     brand:
-        'inline-flex w-full items-center justify-center rounded-full bg-[#e0e1dc] px-8 py-3 font-serif text-lg font-semibold text-[#415a78] transition-colors duration-200 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:cursor-not-allowed disabled:opacity-60',
+        'inline-flex w-full items-center justify-center rounded-full bg-[#e0e1dc] px-8 py-3 font-serif text-lg font-semibold text-black transition-colors duration-200 hover:bg-[#1b263b] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 disabled:cursor-not-allowed disabled:opacity-60',
 };
 
 export default function PrimaryButton({

--- a/resources/js/Layouts/AuthLayout.jsx
+++ b/resources/js/Layouts/AuthLayout.jsx
@@ -33,7 +33,7 @@ export default function AuthLayout({
                 >
                     <main
                         className={`flex w-full justify-center px-6 pb-12 ${
-                            hasAside ? 'lg:px-16' : ''
+                            hasAside ? 'lg:w-1/2 lg:px-16' : ''
                         }`.trim()}
                     >
                         <div
@@ -48,7 +48,7 @@ export default function AuthLayout({
                     {hasAside && (
                         <>
                             <div
-                                className={`hidden lg:flex lg:w-[32rem] lg:shrink-0 lg:items-stretch ${
+                                className={`hidden lg:flex lg:w-1/2 lg:shrink-0 lg:items-stretch ${
                                     asideClassName
                                 }`.trim()}
                             >

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -30,14 +30,14 @@ export default function Login({ status, canResetPassword, canRegister }) {
     const asideContent = (
         <div className="flex flex-col items-center text-center text-white">
             <img
-                src="/images/lézard-blanc.png"
-                alt="Illustration d'un lézard"
+                src="/images/loup-blanc.png"
+                alt="Illustration d'un loup"
                 className="w-full max-w-sm"
             />
 
-            <p className="mt-10 max-w-sm text-lg text-white/80">
-                Accédez à votre espace Totem Mind pour continuer vos quêtes,
-                suivre vos gains et profiter des sondages exclusifs.
+            <p className="mt-10 max-w-sm font-serif text-lg text-white/80">
+                Accédez à votre espace Totem Mind pour continuer les
+                sondages rémunérés !
             </p>
         </div>
     );
@@ -61,10 +61,6 @@ export default function Login({ status, canResetPassword, canRegister }) {
                     <h1 className="text-4xl font-semibold text-white">
                         Se connecter
                     </h1>
-                    <p className="mt-4 text-sm text-white/70">
-                        Retrouvez votre espace personnel et continuez l'aventure
-                        Totem Mind.
-                    </p>
                 </div>
 
                 {status && (
@@ -133,7 +129,7 @@ export default function Login({ status, canResetPassword, canRegister }) {
                                 onChange={(e) =>
                                     setData('remember', e.target.checked)
                                 }
-                                className="size-5 border-white/40 text-brand-sand focus:ring-brand-sand focus:ring-offset-0"
+                                className="size-5 border-white/40 text-[#1d263d] focus:ring-brand-sand focus:ring-offset-0"
                             />
                             <span>Se souvenir de moi</span>
                         </label>
@@ -162,11 +158,10 @@ export default function Login({ status, canResetPassword, canRegister }) {
             {canRegister && (
                 <p className="mt-12 text-center text-sm text-white/80">
                     Pas encore de compte ?{' '}
-                    <Link
-                        href={route('register')}
-                        className="font-semibold text-white hover:text-brand-sand"
-                    >
-                        Inscrivez-vous !
+                    <Link href={route('register')} className="font-semibold">
+                        <span className="rounded-full bg-white px-2 py-1 text-brand-midnight">
+                            Inscrivez-vous !
+                        </span>
                     </Link>
                 </p>
             )}


### PR DESCRIPTION
## Summary
- update the login sidebar imagery and messaging with the new copy and font treatment
- tweak the login form styling, including highlighted sign-up link and adjusted checkbox color
- align the auth layout widths so the left and right panels split the screen evenly and update the primary button hover colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de85a460808330b442eba715b7ea4c