### PR TITLE
Adjust spacing and size for account validated illustration

### DIFF
--- a/resources/js/Pages/Auth/AccountValidated.jsx
+++ b/resources/js/Pages/Auth/AccountValidated.jsx
@@ -14,7 +14,7 @@ export default function AccountValidated() {
             <img
                 src="/images/renard-blanc.png"
                 alt="Illustration d'un renard"
-                className="w-full max-w-lg"
+                className="mt-[100px] w-[70%] max-w-lg"
             />
 
             <div className="mt-16 flex w-full max-w-3xl items-center gap-8">


### PR DESCRIPTION
## Summary
- add top spacing before the account validation illustration
- scale the illustration down to 70% width for better balance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de85dc88a083308490c7d612288b39