### PR TITLE
Switch auth CTA prompts to underline styling

### DIFF
--- a/resources/js/Pages/Auth/ForgotPassword.jsx
+++ b/resources/js/Pages/Auth/ForgotPassword.jsx
@@ -108,7 +108,7 @@ export default function ForgotPassword({ status }) {
 
             <Link
                 href={route('login')}
-                className="rounded-full bg-white/20 px-4 py-1 text-sm font-semibold text-white transition-colors hover:bg-white/30 hover:text-brand-sand"
+                className="text-sm font-semibold text-white underline decoration-2 underline-offset-4 transition-colors hover:text-brand-sand"
             >
                 Essayer de vous reconnecter
             </Link>

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -158,10 +158,11 @@ export default function Login({ status, canResetPassword, canRegister }) {
             {canRegister && (
                 <p className="mt-12 text-center text-sm text-white/80">
                     Pas encore de compte ?{' '}
-                    <Link href={route('register')} className="font-semibold">
-                        <span className="rounded-full bg-white px-2 py-1 text-brand-midnight">
-                            Inscrivez-vous !
-                        </span>
+                    <Link
+                        href={route('register')}
+                        className="font-semibold text-white underline decoration-2 underline-offset-4 transition-colors hover:text-brand-sand"
+                    >
+                        Inscrivez-vous !
                     </Link>
                 </p>
             )}

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -447,7 +447,7 @@ export default function Register() {
                 Déjà inscrit ?{' '}
                 <Link
                     href={route('login')}
-                    className="inline-block rounded-full bg-white px-4 py-2 font-semibold text-brand-midnight transition-colors hover:bg-brand-sand hover:text-brand-midnight"
+                    className="inline-block font-semibold text-white underline decoration-2 underline-offset-4 transition-colors hover:text-brand-sand"
                 >
                     Connectez-vous !
                 </Link>


### PR DESCRIPTION
## Summary
- update the forgot password page reconnect prompt to use underline styling instead of the previous pill treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8ae17f008330a6ef4f98b5c72048