### PR TITLE
Style survey dashboard hero with decorative assets

### DIFF
--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -8,11 +8,19 @@ export default function Dashboard() {
 
             <div className="relative flex w-full flex-col overflow-hidden px-6 py-12 sm:px-10 lg:px-16 lg:py-16">
                 <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col gap-10 text-[#081b2e]">
-                    <div className="flex flex-col gap-4">
-                        <h1 className="text-4xl font-semibold text-[#081b2e]">Sondages rémunérés</h1>
-                        <p className="max-w-2xl text-base text-[#081b2e]/80">
-                            Certains sondages vous donnent des récompenses même si vous n'êtes pas sélectionné(e) !
-                        </p>
+                    <div className="relative overflow-hidden rounded-3xl bg-[#12385b] px-8 py-10 text-white shadow-lg">
+                        <div className="flex flex-col gap-4">
+                            <h1 className="text-4xl font-semibold text-white">Sondages rémunérés</h1>
+                            <p className="max-w-2xl text-base text-white/80">
+                                Certains sondages vous donnent des récompenses même si vous n'êtes pas sélectionné(e) !
+                            </p>
+                        </div>
+
+                        <img
+                            src="/images/element-08.png"
+                            alt="Illustration décorative Totem Mind"
+                            className="pointer-events-none absolute -top-12 right-0 h-40 w-auto max-w-none translate-x-10"
+                        />
                     </div>
 
                     <div className="rounded-3xl border border-dashed border-[#081b2e]/20 bg-white/60 px-6 py-6 text-sm italic text-[#081b2e]/70">
@@ -21,12 +29,12 @@ export default function Dashboard() {
 
                     <div className="flex flex-1 flex-col items-center justify-center gap-8 text-center">
                         <img
-                            src="/images/element-08.png"
-                            alt="Illustration décorative Totem Mind"
-                            className="h-24 w-auto"
+                            src="/images/paysage.png"
+                            alt="Illustration de paysage Totem Mind"
+                            className="h-auto w-full max-w-md"
                         />
 
-                        <p className="max-w-3xl text-2xl font-semibold leading-snug text-[#333333] font-serif">
+                        <p className="max-w-3xl text-2xl font-serif font-semibold leading-snug text-[#333333]">
                             On dirait qu'il n'y a plus de sondages disponibles pour le moment, revenez dans quelques heures !
                         </p>
                     </div>


### PR DESCRIPTION
## Summary
- wrap the survey dashboard hero in a blue banner background with the decorative element-08 asset positioned at the top right
- refresh the empty state illustration by swapping in the paysage artwork in the center of the page

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e031d5a3c48330ad608727ef365cc8