### PR TITLE
Adjust email notifications checkbox color and description

### DIFF
--- a/resources/js/Components/Checkbox.jsx
+++ b/resources/js/Components/Checkbox.jsx
@@ -4,7 +4,7 @@ export default function Checkbox({ className = '', ...props }) {
             {...props}
             type="checkbox"
             className={
-                'rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500 ' +
+                'rounded border-gray-300 text-[#1d263d] shadow-sm focus:ring-[#1d263d] ' +
                 className
             }
         />

--- a/resources/js/Pages/Auth/EmailNotifications.jsx
+++ b/resources/js/Pages/Auth/EmailNotifications.jsx
@@ -68,8 +68,7 @@ export default function EmailNotifications() {
                         Notifications par e-mail
                     </h1>
                     <p className="mt-4 text-sm text-white/70">
-                        Personnalisez les alertes reçues pour suivre l’actualité
-                        des sondages, de vos gains et des nouveautés Totem Mind.
+                        Recevez des rappels de vos gains à retirer.
                     </p>
                 </div>
 


### PR DESCRIPTION
## Summary
- update the shared Checkbox component to use the #1d263d brand color for checked and focus states
- replace the hero description on the email notifications page with the new reminder copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0326e87b08330919246160ac148fc