### PR TITLE
Adjust reset password messaging and imagery

### DIFF
--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -76,7 +76,7 @@ export default function Login({
                 </div>
 
                 {status && (
-                    <div className="mt-6 rounded-full bg-emerald-400/20 px-6 py-3 text-center text-sm font-semibold text-emerald-100">
+                    <div className="mt-6 rounded-full bg-[#1b263b] px-6 py-3 text-center text-sm font-semibold text-white">
                         {status}
                     </div>
                 )}

--- a/resources/js/Pages/Auth/ResetPassword.jsx
+++ b/resources/js/Pages/Auth/ResetPassword.jsx
@@ -24,15 +24,10 @@ export default function ResetPassword({ token, email }) {
     const asideContent = (
         <div className="flex flex-col items-center text-center text-white">
             <img
-                src="/images/palette.png"
-                alt="Palette de couleurs Totem"
+                src="/images/lézard-blanc.png"
+                alt="Lézard Totem"
                 className="w-full max-w-sm"
             />
-
-            <p className="mt-10 max-w-sm text-lg text-white/80">
-                Choisissez un nouveau mot de passe sécurisé pour continuer vos
-                explorations dans l’univers Totem Mind.
-            </p>
         </div>
     );
 


### PR DESCRIPTION
## Summary
- update the reset password sidebar to use the lizard illustration and remove the descriptive paragraph
- restyle the success status banner on the login page to use the requested color palette

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0352857f08330a7acba5977ddc7b8