### PR TITLE
Fix Socialite bootstrap configuration

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Socialite\SocialiteServiceProvider;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -10,6 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    ->withProviders([
+        SocialiteServiceProvider::class,
+    ])
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->web(append: [
             \App\Http\Middleware\AuthenticateUsingRememberCookie::class,


### PR DESCRIPTION
## Summary
- remove the unsupported alias registration call when bootstrapping the application to prevent runtime errors
- continue registering the Socialite service provider so the factory binding is available

## Testing
- not run (vendor dependencies are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0cfc060888330add3af8d566eceab