### PR TITLE
Adjust dashboard balance badge layout

### DIFF
--- a/resources/js/Layouts/SurveyLayout.jsx
+++ b/resources/js/Layouts/SurveyLayout.jsx
@@ -26,17 +26,18 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
                             <ApplicationLogo className="h-14 w-auto" />
                         </Link>
 
-                        <div className="mt-10 flex items-center justify-between rounded-3xl border border-white/10 bg-white/5 px-5 py-4">
-                            <div className="flex flex-col gap-1">
-                                <p className="text-xs text-white/60">Bonjour</p>
-                                <p className="text-sm font-semibold text-white">{user?.email}</p>
-                            </div>
+                        <div className="relative mt-10 rounded-3xl border border-white/10 bg-white/5 px-5 pb-5 pt-8">
                             <span
-                                className="inline-flex items-center gap-1 rounded-full bg-white px-4 py-1 text-sm font-semibold text-[#081b2e]"
+                                className="absolute -top-4 left-5 inline-flex items-center gap-1 rounded-full bg-white px-4 py-1 text-sm font-semibold text-[#081b2e] shadow-lg shadow-black/20"
                             >
                                 <span>1</span>
                                 <span>€</span>
                             </span>
+
+                            <div className="flex flex-col gap-1">
+                                <p className="text-xs text-white/60">Bonjour</p>
+                                <p className="text-sm font-semibold text-white">{user?.email}</p>
+                            </div>
                         </div>
 
                         <nav className="mt-12 flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- reposition the dashboard earnings badge above the greeting inside the survey layout card
- add spacing and a subtle shadow so the badge visually floats like in the provided mockup

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0d49501ec833083174a239d170ff4