### PR TITLE
Adjust account validated illustration sizing

### DIFF
--- a/resources/js/Pages/Auth/AccountValidated.jsx
+++ b/resources/js/Pages/Auth/AccountValidated.jsx
@@ -14,7 +14,7 @@ export default function AccountValidated() {
             <img
                 src="/images/renard-blanc.png"
                 alt="Illustration d'un renard"
-                className="mt-[100px] w-[70%] max-w-md"
+                className="mt-[100px] w-full max-w-xs"
             />
 
             <div className="mt-16 flex w-full max-w-3xl flex-col items-center gap-4 sm:flex-row sm:gap-8">


### PR DESCRIPTION
## Summary
- reduce the illustration width on the account validation screen to match the forgot password page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b5fa7b088330b847f03da6a40184