### PR TITLE
Customize 429 error message

### DIFF
--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Trop de requêtes'))
+@section('code', '429')
+@section('message', __('Une autre adresse mail créée depuis le même ordinateur existe déjà, merci d\'utiliser celle-ci !'))


### PR DESCRIPTION
## Summary
- add a custom 429 error view overriding the default message with tailored French copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b63eeb888330be70d29fa5789774