### PR TITLE
Adjust dashboard background colors

### DIFF
--- a/resources/js/Layouts/SurveyLayout.jsx
+++ b/resources/js/Layouts/SurveyLayout.jsx
@@ -20,7 +20,7 @@ export default function SurveyLayout({ children, activeItem = 'surveys' }) {
     return (
         <div className="flex min-h-screen flex-col bg-[#071522] text-white">
             <div className="flex flex-1 flex-col lg:flex-row">
-                <aside className="w-full bg-[#212a3a] px-8 py-10 lg:w-80">
+                <aside className="w-full bg-[#1d263d] px-8 py-10 lg:w-80">
                     <div className="flex h-full flex-col">
                         <Link href="/" className="flex items-center gap-4 text-white">
                             <ApplicationLogo className="h-14 w-auto" />

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -8,7 +8,7 @@ export default function Dashboard() {
 
             <div className="relative flex w-full flex-col overflow-hidden px-0 pb-12 sm:pb-16">
                 <div className="relative flex w-full flex-col gap-10 text-[#081b2e]">
-                    <div className="relative -mx-6 flex flex-col gap-4 bg-[#12385b] px-6 py-16 text-white sm:-mx-10 sm:px-10 lg:-mx-16 lg:px-16">
+                    <div className="relative -mx-6 flex flex-col gap-4 bg-[#415a77] px-6 py-16 text-white sm:-mx-10 sm:px-10 lg:-mx-16 lg:px-16">
                         <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
 
                             <h1 className="text-4xl font-semibold text-white">Sondages rémunérés</h1>


### PR DESCRIPTION
## Summary
- update the dashboard sidebar background to use #1d263d
- refresh the hero section behind "Sondages rémunérés" with the new #415a77 tone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b610964c8330bb4eb8351be8dc9a