### PR TITLE
Hide Google reCAPTCHA testing warning message globally

### DIFF
--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -246,17 +246,21 @@ export default function Register({ socialProviders = [] }) {
     }, [isRecaptchaReady, siteKey, clearErrors, setData]);
 
     useEffect(() => {
+        if (! isRecaptchaReady) {
+            return;
+        }
+
         if (
-            ! recaptchaContainerRef.current ||
             typeof window === 'undefined' ||
+            typeof document === 'undefined' ||
             typeof window.MutationObserver === 'undefined'
         ) {
             return;
         }
 
-        const container = recaptchaContainerRef.current;
+        const rootNode = document.body ?? document;
         const hideTestMessage = () => {
-            const candidateNodes = container.querySelectorAll('div');
+            const candidateNodes = rootNode.querySelectorAll('div');
 
             candidateNodes.forEach((node) => {
                 if (
@@ -279,7 +283,7 @@ export default function Register({ socialProviders = [] }) {
             hideTestMessage();
         });
 
-        observer.observe(container, {
+        observer.observe(rootNode, {
             childList: true,
             subtree: true,
         });


### PR DESCRIPTION
## Summary
- observe the document body to hide the Google reCAPTCHA testing banner wherever it is inserted
- guard the observer setup until the widget is ready and clean up the mutation observer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b94710cc833087eb4cb9821eead8