### PR TITLE
Hide reCAPTCHA testing notice

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -20,3 +20,7 @@
         @apply font-serif;
     }
 }
+
+.register-recaptcha .rc-anchor-error-msg-container {
+    display: none !important;
+}

--- a/resources/js/Pages/Auth/Register.jsx
+++ b/resources/js/Pages/Auth/Register.jsx
@@ -488,7 +488,7 @@ export default function Register({ socialProviders = [] }) {
                     <div className="flex flex-col items-center">
                         <div
                             ref={recaptchaContainerRef}
-                            className="mx-auto flex min-h-[78px] items-center justify-center"
+                            className="register-recaptcha mx-auto flex min-h-[78px] items-center justify-center"
                         />
 
                         <InputError


### PR DESCRIPTION
## Summary
- add a custom CSS class to the reCAPTCHA container on the registration page
- hide Google's red testing notice inside the reCAPTCHA widget to match the desired appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c8fb8c3c8330901d906fb69cf15d