### PR TITLE
Use server-provided reCAPTCHA configuration

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -29,10 +29,17 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        $recaptchaSiteKey = (string) config('services.recaptcha.site_key', '');
+        $recaptchaTestKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
+            ],
+            'recaptcha' => [
+                'siteKey' => $recaptchaSiteKey,
+                'isSandbox' => hash_equals($recaptchaTestKey, $recaptchaSiteKey),
             ],
         ];
     }


### PR DESCRIPTION
## Summary
- share the configured reCAPTCHA keys with Inertia responses so the frontend always receives production credentials
- detect sandbox keys on the client and only apply banner-hiding logic when the Google test key is being used

## Testing
- not run (vendor autoload missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68e44151d5a883309879d8da0cfacb80