### PR TITLE
Handle registration throttling with form error

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
+use Illuminate\Http\Request;
 use Laravel\Socialite\SocialiteServiceProvider;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -24,5 +27,43 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->render(function (ThrottleRequestsException $exception, Request $request) {
+            if (! $request->routeIs('register')) {
+                return null;
+            }
+
+            $retryAfterHeader = $exception->getHeaders()['Retry-After']
+                ?? $exception->getHeaders()['retry-after']
+                ?? null;
+
+            $retryAfter = is_numeric($retryAfterHeader)
+                ? (int) $retryAfterHeader
+                : 0;
+
+            $retryAfter = max($retryAfter, 1);
+
+            $ipAlreadyRegistered = $request->ip() !== null
+                && User::query()
+                    ->where('registration_ip', $request->ip())
+                    ->exists();
+
+            $message = $ipAlreadyRegistered
+                ? __('Les inscriptions multiples depuis la même adresse IP ne sont pas autorisées.')
+                : trans('auth.throttle', [
+                    'seconds' => $retryAfter,
+                    'minutes' => (int) ceil($retryAfter / 60),
+                ]);
+
+            return back()
+                ->withInput(
+                    $request->except([
+                        'password',
+                        'password_confirmation',
+                        'captcha_token',
+                    ])
+                )
+                ->withErrors([
+                    'email' => $message,
+                ]);
+        });
     })->create();


### PR DESCRIPTION
## Summary
- catch registration throttling exceptions and convert them into validation errors
- surface a clear error message on the registration form instead of the generic 429 page
- preserve the user input (except sensitive fields) when the throttling limit is hit

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c3f255ec833085b0da717b908997